### PR TITLE
Show the entryId in the url as a param.

### DIFF
--- a/frontend/src/components/entries/Index.jsx
+++ b/frontend/src/components/entries/Index.jsx
@@ -6,8 +6,9 @@ import Entry from './thoughts/Entry';
 import Thoughts from './thoughts/Thoughts';
 
 import { styled } from '@mui/material/styles';
+import { useParams } from 'react-router-dom';
 
-const testJournal = '6555c8b561fb25d5edb15ea7';
+const testJournal = '65593317c6e03734e710a80c';
 
 const Item = styled(Paper)(({ theme }) => ({
     backgroundColor: theme.palette.mode === 'dark' ? '#282828' : '#fff',
@@ -24,6 +25,8 @@ export default function Entries() {
     const [focusedEntryId, setFocusedEntryId] = useState('');
     const [editedEntryId, setEditedEntryId] = useState('');
 
+    const { entryId } = useParams();
+
     useEffect(() => {
         const makeRequest = async () => {
             try {
@@ -37,7 +40,14 @@ export default function Entries() {
                 }
                 const data = await response.json();
                 setEntries([...data.entries]);
-                setFocusedEntryId(data.entries.length ? data.entries[0]._id : '')
+
+                // If the URL has a specific entry ID, set that as the focused entry
+                if (entryId) {
+                    setFocusedEntryId(entryId);
+                } else {
+                    setFocusedEntryId(data.entries.length ? data.entries[0]._id : '');
+                }
+
             } catch (error) {
                 console.error('Error:', error);
             }

--- a/frontend/src/components/entries/thoughts/Entry.jsx
+++ b/frontend/src/components/entries/thoughts/Entry.jsx
@@ -1,10 +1,13 @@
 import { Box, Button, InputLabel, TextField, Typography } from '@mui/material';
 
+import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
 export default function Entry({ testJournal, setEntries, setFocusedEntryId }) {
     const [newEntry, setNewEntry] = useState('');
     const [validationError, setValidationError] = useState('');
+
+    const navigate = useNavigate();
 
     const handleNewEntryChange = (event) => {
         setNewEntry(event.target.value);
@@ -56,6 +59,7 @@ export default function Entry({ testJournal, setEntries, setFocusedEntryId }) {
 
             // Make the new entry the focused entry on submit
             setFocusedEntryId(data._id);
+            navigate(`/entries/${ data._id }`);
 
             // Add new entry to thought list
             setEntries((entries) => (

--- a/frontend/src/components/entries/thoughts/Thoughts.jsx
+++ b/frontend/src/components/entries/thoughts/Thoughts.jsx
@@ -3,6 +3,7 @@ import './Thoughts.css'
 import { Box, Button, IconButton, TextField, Typography } from '@mui/material';
 import { Delete as DeleteIcon, Edit as EditIcon, AspectRatio as FocusIcon } from '@mui/icons-material';
 
+import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
 export default function Thoughts({ journalId, entries, setEntries, focusedEntryId, setFocusedEntryId, editedEntryId, setEditedEntryId }) {
@@ -15,6 +16,7 @@ export default function Thoughts({ journalId, entries, setEntries, focusedEntryI
         privacy_settings: {},
     });
     const [validationError, setValidationError] = useState('');
+    const navigate = useNavigate();
 
     const handleFocus = async (entryId) => {
         // Scroll to top of page
@@ -22,6 +24,7 @@ export default function Thoughts({ journalId, entries, setEntries, focusedEntryI
 
         // Focus thought analysis view on selected entry
         setFocusedEntryId(entryId);
+        navigate(`/entries/${ entryId }`);
     }
 
     const handleEnterKeyPress = (event) => {
@@ -129,11 +132,11 @@ export default function Thoughts({ journalId, entries, setEntries, focusedEntryI
 
             // Remove the deleted entry from the state
             setEntries(filteredEntries);
+            navigate(`/entries/${ entryId }`);
         } catch (error) {
             console.error('Error:', error);
         }
     };
-
 
     return (
         <div>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -16,7 +16,21 @@ const router = createBrowserRouter([
     children: [
       {
         path: '/entries',
-        element: <Index />
+        element: <Index />,
+        children: [
+          {
+            path: ':entryId',
+            element: <Index />
+          },
+          {
+            path: ':entryId/analysis',
+            element: <Index />
+          },
+          {
+            path: ':entryId/chat',
+            element: <Index />
+          },
+        ],
       },
       {
         path: '/account',


### PR DESCRIPTION
This PR introduces dynamic routing. This includes,
- Updating the url when a user focuses on an entry `/entries/:{entryId}`
- Focus on an existing entry if the url contains an entryId param `/entries/:{entryId}`
  - Return a 404 error if an entry is not found under a given entryId. 
- Add subroutes on entries based on the entry API
  - The entry will be returned if the user adds to the end of url `/analysis` or `/chat`  provided the entry with the entryId exists

Note for full API access, the user should be able to access an entry by chatId. Currently this GET endpoint does not exists as it doesn't seem clear how the user will attain the chat url or if it is necessary considering every chat can be access with a given entryId (it doesn't seem necessary currently).