### PR TITLE
Upgrade local dev environment to https.

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,11 +1,18 @@
 import app from './src/app.js';
-import express from 'express';
+import dotenv from 'dotenv';
+import fs from 'fs';
+import https from 'https';
 
-const port = 3000;
-const server = express();
+if (process.env.NODE_ENV !== 'production') {
+  dotenv.config();
+}
 
-server.use(app);
+const privateKey = fs.readFileSync(process.env.PRIVATE_KEY_PATH, 'utf8');
+const certificate = fs.readFileSync(process.env.CERTIFICATE_PATH, 'utf8');
 
-server.listen(port, () => {
-  console.log(`\nEXPRESS Listening on port ${ port }.`);
+const credentials = { key: privateKey, cert: certificate };
+const httpsServer = https.createServer(credentials, app);
+
+httpsServer.listen(process.env.HTTPS_PORT, () => {
+  console.log(`\nHTTPS Listening on port ${ process.env.HTTPS_PORT }`);
 });

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -18,11 +18,17 @@ if (process.env.NODE_ENV !== 'test') {
   connectDB('cdj').catch(err => console.log(err));
 }
 
+const corsOptions = {
+  origin: [
+    process.env.DEV_ORIGIN_LOCAL_URL,
+    process.env.DEV_ORIGIN_PRIVATE_URL
+  ],
+  credentials: true,
+  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE'
+};
+
 // use cors middleware
-app.use(cors({
-  origin: ['https://192.168.50.157:5173', 'https://localhost:5173'],
-  credentials: true
-}));
+app.use(cors(corsOptions));
 
 // use json middleware
 app.use(express.json());
@@ -33,9 +39,9 @@ app.use(session({
   resave: false,
   saveUninitialized: false,
   cookie: {
-    secure: process.env.NODE_ENV === 'production',
+    secure: true,
     httpOnly: true,
-    sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+    sameSite: 'none',
     expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7),
     maxAge: 1000 * 60 * 60 * 24 * 7 // 1 week
   }

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,17 +5,11 @@ import User from './models/user.js';
 
 import connectDB from './db.js';
 import cors from 'cors';
-import dotenv from 'dotenv';
 import express from 'express';
 import flash from 'connect-flash';
 import morgan from 'morgan';
 import passport from 'passport';
 import session from 'express-session';
-
-// load environment variables
-if (process.env.NODE_ENV !== 'production') {
-  dotenv.config();
-}
 
 const app = express();
 
@@ -26,7 +20,7 @@ if (process.env.NODE_ENV !== 'test') {
 
 // use cors middleware
 app.use(cors({
-  origin: ['http://localhost:5173', 'http://192.168.50.157:5173'],
+  origin: ['https://192.168.50.157:5173', 'https://localhost:5173'],
   credentials: true
 }));
 

--- a/backend/src/models/user.js
+++ b/backend/src/models/user.js
@@ -176,7 +176,7 @@ userSchema.methods.sendPasswordResetEmail = async function (token) {
 
   // TODO: Change this to the actual URL of the frontend app when deployed
   // Construct the password reset URL
-  const resetUrl = `http://192.168.50.157:5173/reset-password?token=${ token }`;
+  const resetUrl = `https://192.168.50.157:5173/reset-password?token=${ token }`;
 
   // Email content
   const message = {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@fontsource/roboto": "^5.0.8",
         "@mui/icons-material": "^5.14.16",
         "@mui/material": "^5.14.18",
+        "dotenv": "^16.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.18.0",
@@ -1949,6 +1950,17 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -5755,6 +5767,11 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "electron-to-chromium": {
       "version": "1.4.578",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@fontsource/roboto": "^5.0.8",
     "@mui/icons-material": "^5.14.16",
     "@mui/material": "^5.14.18",
+    "dotenv": "^16.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",

--- a/frontend/src/components/nav/menus/UserMenu.jsx
+++ b/frontend/src/components/nav/menus/UserMenu.jsx
@@ -11,7 +11,7 @@ export default function UserMenu({
         <Box sx={{ flexGrow: 0 }}>
             <Tooltip title="Open settings">
                 <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
-                    <Avatar alt="Remy Sharp" src="/static/images/avatar/2.jpg" />
+                    <Avatar alt="The CDJ" />
                 </IconButton>
             </Tooltip>
             <Menu

--- a/frontend/src/hooks/useAccess.jsx
+++ b/frontend/src/hooks/useAccess.jsx
@@ -1,7 +1,7 @@
 import { useFlash } from '../context/useFlash';
 import { v4 as uuid } from 'uuid';
 
-const BASE_URL = 'http://192.168.50.157:3000/access';
+const BASE_URL = import.meta.env.VITE_BASE_ACCESS_URL;
 
 export function useAccess() {
     const { setFlash } = useFlash();

--- a/frontend/src/hooks/useEntries.jsx
+++ b/frontend/src/hooks/useEntries.jsx
@@ -3,7 +3,7 @@ import { useJournal } from '../context/useJournal';
 
 import { v4 as uuid } from 'uuid';
 
-const BASE_URL = 'http://192.168.50.157:3000/journals/';
+const BASE_URL = import.meta.env.VITE_BASE_ENTRIES_URL;
 
 export function useEntries() {
     const { journalId } = useJournal();

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,10 +1,22 @@
+/* eslint-disable no-undef */
 import { defineConfig } from 'vite'
+
+import dotenv from 'dotenv'
+import fs from 'fs'
 import react from '@vitejs/plugin-react'
+
+if (process.env.NODE_ENV !== 'production') {
+  dotenv.config({ path: '../backend/.env' })
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-  },
+    https: {
+      key: fs.readFileSync(process.env.VITE_PRIVATE_KEY_PATH, 'utf8'),
+      cert: fs.readFileSync(process.env.VITE_CERTIFICATE_PATH, 'utf8'),
+    },
+  }
 })

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,7 @@ import fs from 'fs'
 import react from '@vitejs/plugin-react'
 
 if (process.env.NODE_ENV !== 'production') {
-  dotenv.config({ path: '../backend/.env' })
+  dotenv.config()
 }
 
 // https://vitejs.dev/config/
@@ -15,8 +15,8 @@ export default defineConfig({
   server: {
     host: true,
     https: {
-      key: fs.readFileSync(process.env.VITE_PRIVATE_KEY_PATH, 'utf8'),
-      cert: fs.readFileSync(process.env.VITE_CERTIFICATE_PATH, 'utf8'),
+      key: fs.readFileSync(process.env.PRIVATE_KEY_PATH, 'utf8'),
+      cert: fs.readFileSync(process.env.CERTIFICATE_PATH, 'utf8'),
     },
   }
 })


### PR DESCRIPTION
This (attempts) to make the local development servers (vite and express) serve over https which will make the development environment look closer to actual production. The first commits setup `cors` (on both vite an express) and `session` (in only express) to run only securely on both production and development environments. Some additional security practices have been implemented such as moving all exposed urls to .env and resolves minor errors such as removing the account icon that did not load from its original src. 

Note that in order to run the server over HTTPS you need your own SSL Certificate Authority (CA) and certificates need to be loaded into the servers requesting HTTPS access. This [website](https://deliciousbrains.com/ssl-certificate-authority-for-local-https-development/) provides a good reference to becoming a tiny CA and creating certificates needed. Even having followed this and importing certificates into the servers the browser still doesn't recognize the site as secure even with it being served as `https` (see Issue #28 for more information).