### PR TITLE
Remove Copyright duplication.

### DIFF
--- a/frontend/src/components/access/private/Account/Account.jsx
+++ b/frontend/src/components/access/private/Account/Account.jsx
@@ -2,7 +2,7 @@ import { Box, Button, Container, LinearProgress, Paper, Step, StepLabel, Stepper
 import { useEffect, useState } from 'react';
 
 import Config from './Forms/Config';
-import MenuLink from '../../../nav/menus/MenuLink';
+import Copyright from '../../../utils/Copyright';
 import Password from './Forms/Password';
 import Profile from './Forms/Profile';
 import Review from './Forms/Review';
@@ -41,21 +41,6 @@ const removeMatchingProperties = (source, reference) => {
         });
     }
 };
-
-
-function Copyright(props) {
-    return (
-        <Typography align="center" color="text.secondary" variant="body2" {...props}>
-            {'© 2023 '}
-            <MenuLink
-                page={{
-                    label: 'The Cognitive Distortion Journal',
-                    name: '',
-                    visibility: ''
-                }} />
-        </Typography>
-    );
-}
 
 export default function Account() {
     const [activeStep, setActiveStep] = useState(0);

--- a/frontend/src/components/access/private/Logout.jsx
+++ b/frontend/src/components/access/private/Logout.jsx
@@ -3,25 +3,11 @@ import { useEffect, useState } from 'react';
 
 import { AltRoute } from '@mui/icons-material';
 
-import MenuLink from '../../../components/nav/menus/MenuLink';
+import Copyright from '../../utils/Copyright';
 
 import { useAccess } from '../../../hooks/useAccess';
 import { useJournal } from '../../../contexts/useJournal';
 import { useNavigate } from 'react-router-dom';
-
-function Copyright(props) {
-    return (
-        <Typography align="center" color="text.secondary" variant="body2" {...props}>
-            {'© 2023 '}
-            <MenuLink
-                page={{
-                    label: 'The Cognitive Distortion Journal',
-                    name: '',
-                    visibility: ''
-                }} />
-        </Typography>
-    );
-}
 
 export default function Logout() {
     const { setJournalId, setJournalTitle } = useJournal();

--- a/frontend/src/components/access/public/ForgotPassword.jsx
+++ b/frontend/src/components/access/public/ForgotPassword.jsx
@@ -2,26 +2,13 @@ import { Avatar, Box, Button, Container, Grid } from '@mui/material';
 
 import { AltRoute } from '@mui/icons-material';
 
+import Copyright from '../../utils/Copyright';
 import MenuLink from '../../../components/nav/menus/MenuLink';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
 import { useAccess } from '../../../hooks/useAccess';
 import { useNavigate } from 'react-router-dom';
-
-function Copyright(props) {
-    return (
-        <Typography align="center" color="text.secondary" variant="body2" {...props}>
-            {'© 2023 '}
-            <MenuLink
-                page={{
-                    label: 'The Cognitive Distortion Journal',
-                    name: '',
-                    visibility: ''
-                }} />
-        </Typography>
-    );
-}
 
 export default function ForgotPassword() {
     const access = useAccess();

--- a/frontend/src/components/access/public/Login.jsx
+++ b/frontend/src/components/access/public/Login.jsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { AltRoute } from '@mui/icons-material';
 
+import Copyright from '../../utils/Copyright';
 import MenuLink from '../../../components/nav/menus/MenuLink';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -10,20 +11,6 @@ import Typography from '@mui/material/Typography';
 import { useAccess } from '../../../hooks/useAccess';
 import { useJournal } from '../../../contexts/useJournal';
 import { useState } from 'react';
-
-function Copyright(props) {
-    return (
-        <Typography align="center" color="text.secondary" variant="body2" {...props}>
-            {'© 2023 '}
-            <MenuLink
-                page={{
-                    label: 'The Cognitive Distortion Journal',
-                    name: '',
-                    visibility: ''
-                }} />
-        </Typography>
-    );
-}
 
 export default function Login() {
     const [isRememberMeChecked, setIsRememberMeChecked] = useState(false);

--- a/frontend/src/components/access/public/Register.jsx
+++ b/frontend/src/components/access/public/Register.jsx
@@ -2,6 +2,7 @@ import { Avatar, Box, Button, Container, Grid } from '@mui/material';
 
 import { AltRoute } from '@mui/icons-material';
 
+import Copyright from '../../utils/Copyright';
 import MenuLink from '../../../components/nav/menus/MenuLink';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -9,20 +10,6 @@ import Typography from '@mui/material/Typography';
 import { useAccess } from '../../../hooks/useAccess';
 import { useJournal } from '../../../contexts/useJournal';
 import { useNavigate } from 'react-router-dom';
-
-function Copyright(props) {
-    return (
-        <Typography align="center" color="text.secondary" variant="body2" {...props}>
-            {'© 2023 '}
-            <MenuLink
-                page={{
-                    label: 'The Cognitive Distortion Journal',
-                    name: '',
-                    visibility: ''
-                }} />
-        </Typography>
-    );
-}
 
 export default function Register() {
     const { setJournalId, setJournalTitle } = useJournal();

--- a/frontend/src/components/access/public/ResetPassword.jsx
+++ b/frontend/src/components/access/public/ResetPassword.jsx
@@ -3,24 +3,11 @@ import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import AltRoute from '@mui/icons-material/AltRoute'; // Import appropriate icon
+import Copyright from '../../utils/Copyright';
 import MenuLink from '../../../components/nav/menus/MenuLink';
 
 import { useAccess } from '../../../hooks/useAccess';
 import { useState } from 'react';
-
-function Copyright(props) {
-    return (
-        <Typography align="center" color="text.secondary" variant="body2" {...props}>
-            {'© 2023 '}
-            <MenuLink
-                page={{
-                    label: 'The Cognitive Distortion Journal',
-                    name: '',
-                    visibility: ''
-                }} />
-        </Typography>
-    );
-}
 
 export default function ResetPassword() {
     const [passwords, setPasswords] = useState({ newPassword: '', confirmNewPassword: '' });

--- a/frontend/src/components/utils/Copyright.jsx
+++ b/frontend/src/components/utils/Copyright.jsx
@@ -1,0 +1,16 @@
+import MenuLink from '../nav/menus/MenuLink';
+import { Typography } from '@mui/material';
+
+export default function Copyright(props) {
+    return (
+        <Typography align="center" color="text.secondary" variant="body2" {...props}>
+            {'© 2023 '}
+            <MenuLink
+                page={{
+                    label: 'The Cognitive Distortion Journal',
+                    name: '',
+                    visibility: ''
+                }} />
+        </Typography>
+    );
+}


### PR DESCRIPTION
This PR refactors the in line styles into new styled components that can be reused and easily traceable or updated.

The first PR removes the creates a new Copyright component in utils then removes duplicate definitions and imports the new component to be used in place. 