### PR TITLE
Move urls into env variables.

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -26,7 +26,7 @@ if (process.env.NODE_ENV !== 'test') {
 
 // use cors middleware
 app.use(cors({
-  origin: ['http://localhost:5173', 'http://192.168.50.157:5173'],
+  origin: [process.env.DEV_ORIGIN_LOCAL_URL, process.env.DEV_ORIGIN_PRIVATE_URL],
   credentials: true
 }));
 

--- a/backend/src/assistants/Assistant.js
+++ b/backend/src/assistants/Assistant.js
@@ -1,6 +1,6 @@
 export default class Assistant {
   constructor(bearer, model = '', temperature = 0.7) {
-    this.baseUrl = 'https://api.openai.com/v1';
+    this.baseUrl = process.env.OPENAI_API_URL;
     this.bearer = `Bearer ${ bearer }`;
     this.model = model;
     this.temperature = temperature;

--- a/backend/src/models/user.js
+++ b/backend/src/models/user.js
@@ -176,7 +176,7 @@ userSchema.methods.sendPasswordResetEmail = async function (token) {
 
   // TODO: Change this to the actual URL of the frontend app when deployed
   // Construct the password reset URL
-  const resetUrl = `http://192.168.50.157:5173/reset-password?token=${ token }`;
+  const resetUrl = `${ process.env.DEV_ORIGIN_PRIVATE_URL }/reset-password?token=${ token }`;
 
   // Email content
   const message = {

--- a/frontend/src/hooks/useAccess.jsx
+++ b/frontend/src/hooks/useAccess.jsx
@@ -1,7 +1,7 @@
 import { useFlash } from '../contexts/useFlash';
 import { v4 as uuid } from 'uuid';
 
-const BASE_URL = 'http://192.168.50.157:3000/access';
+const BASE_URL = import.meta.env.VITE_ACCESS_URL;
 
 export function useAccess() {
     const { setFlash } = useFlash();

--- a/frontend/src/hooks/useEntries.jsx
+++ b/frontend/src/hooks/useEntries.jsx
@@ -3,7 +3,7 @@ import { useJournal } from '../contexts/useJournal';
 
 import { v4 as uuid } from 'uuid';
 
-const BASE_URL = 'http://192.168.50.157:3000/journals/';
+const BASE_URL = import.meta.env.VITE_ENTRIES_URL;
 
 export function useEntries() {
     const { journalId } = useJournal();


### PR DESCRIPTION
This PR uses .env to store urls. Previously, urls were hardcoded into the backend (CORS origin, Assistant, and forgot password) and frontend (backend API calls). This makes it easier to update the urls as necessary using env variables. 