### PR TITLE
Make index components scrollable.

### DIFF
--- a/frontend/src/components/entries/analysis/Analysis.jsx
+++ b/frontend/src/components/entries/analysis/Analysis.jsx
@@ -138,10 +138,10 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
 
     return (
         <Item>
-            <Box>
-                <Typography variant="h2">
-                    {focusedData?.entry?.title}
-                </Typography>
+            <Typography variant="h2">
+                {focusedData?.entry?.title}
+            </Typography>
+            <Box sx={{ maxHeight: '45vh', overflow: 'auto' }}>
                 <Grid container spacing={2}>
                     <Grid item md={6} xs={12}>
                         {editing ? (

--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -5,13 +5,15 @@ import Messages from './Messages';
 
 export default function Chat({ journalId, focusedEntryId, chat, setChat }) {
     return (
-        <Box>
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
             <InputLabel htmlFor="new-message" sx={{ color: 'inherit' }}>
                 <Typography variant="h2">Chat</Typography>
             </InputLabel >
-            <Messages
-                chat={chat}
-            />
+            {chat.messages && <Box sx={{ overflow: 'auto', flexGrow: 1, maxHeight: '50vh' }}>
+                <Messages
+                    chat={chat}
+                />
+            </Box>}
             <ChatEntry
                 chat={chat}
                 focusedEntryId={focusedEntryId}

--- a/frontend/src/components/entries/analysis/chat/Messages.jsx
+++ b/frontend/src/components/entries/analysis/chat/Messages.jsx
@@ -1,10 +1,10 @@
 import './Messages.css';
 
-import { Grid, Typography } from '@mui/material';
+import { Box, Grid, Typography } from '@mui/material';
 
 export default function Messages({ chat }) {
     return (
-        <>
+        <Box sx={{ width: '100%' }}>
             {chat && chat.messages && chat.messages.map((message, index) => (
                 <Grid container key={index} margin="0 0 1em" spacing={1}>
                     <Grid item xs={4} />
@@ -26,6 +26,6 @@ export default function Messages({ chat }) {
                     </Grid>
                 </Grid>
             ))}
-        </>
+        </Box>
     );
 }

--- a/frontend/src/components/entries/thoughts/Thoughts.jsx
+++ b/frontend/src/components/entries/thoughts/Thoughts.jsx
@@ -161,82 +161,84 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
                     <Typography variant="h2">Recent Thoughts</Typography>
                 </Grid>
             </Grid>
-            {allEntries.map((entry) => (
-                <Box
-                    className={entry._id === focusedEntryId ? 'focused' : ''}
-                    key={entry._id}
-                    sx={{
-                        margin: '0 0 2em',
-                        padding: '8px 12px',
-                    }}>
-                    <Typography variant="body1">{entry.title}</Typography>
-                    {editing && editedEntryId === entry._id ? (
-                        <>
-                            <TextField
-                                autoFocus
-                                disabled={isSubmitting}
-                                error={Boolean(validationError)}
-                                fullWidth
-                                helperText={validationError}
-                                label="Edit your thought."
-                                maxRows={6}
-                                minRows={3}
-                                multiline
-                                onChange={handleEditing}
-                                onKeyDown={handleEnterKeyPress}
-                                value={editedData.content}
-                                variant="filled"
-                            />
-                            {isSubmitting && <LinearProgress />}
-                            <Box display="flex" justifyContent="flex-end" marginTop={2}>
-                                <Button
-                                    color="primary"
-                                    disabled={Boolean(validationError) || isSubmitting}
-                                    onClick={handleSaveEdit}
-                                    variant="contained"
-                                >
-                                    Save
-                                </Button>
-                                <Button
-                                    color="cancel"
+            <Box sx={{ height: '90vh', overflow: 'auto' }}>
+                {allEntries.map((entry) => (
+                    <Box
+                        className={entry._id === focusedEntryId ? 'focused' : ''}
+                        key={entry._id}
+                        sx={{
+                            margin: '0 0 2em',
+                            padding: '8px 12px',
+                        }}>
+                        <Typography variant="body1">{entry.title}</Typography>
+                        {editing && editedEntryId === entry._id ? (
+                            <>
+                                <TextField
+                                    autoFocus
                                     disabled={isSubmitting}
-                                    onClick={handleCancelEdit}
-                                    style={{ marginLeft: 8 }}
-                                    variant="contained"
+                                    error={Boolean(validationError)}
+                                    fullWidth
+                                    helperText={validationError}
+                                    label="Edit your thought."
+                                    maxRows={6}
+                                    minRows={3}
+                                    multiline
+                                    onChange={handleEditing}
+                                    onKeyDown={handleEnterKeyPress}
+                                    value={editedData.content}
+                                    variant="filled"
+                                />
+                                {isSubmitting && <LinearProgress />}
+                                <Box display="flex" justifyContent="flex-end" marginTop={2}>
+                                    <Button
+                                        color="primary"
+                                        disabled={Boolean(validationError) || isSubmitting}
+                                        onClick={handleSaveEdit}
+                                        variant="contained"
+                                    >
+                                        Save
+                                    </Button>
+                                    <Button
+                                        color="cancel"
+                                        disabled={isSubmitting}
+                                        onClick={handleCancelEdit}
+                                        style={{ marginLeft: 8 }}
+                                        variant="contained"
+                                    >
+                                        Cancel
+                                    </Button>
+                                </Box>
+                            </>
+                        ) : (
+                            <>
+                                <IconButton
+                                    aria-label="Focus"
+                                    color="primary"
+                                    disabled={isSubmitting}
+                                    onClick={() => handleFocus(entry._id)}>
+                                    <FocusIcon />
+                                </IconButton>
+                                <IconButton
+                                    aria-label="Edit"
+                                    color="edit"
+                                    disabled={isSubmitting}
+                                    onClick={() => handleEdit(entry._id)}
                                 >
-                                    Cancel
-                                </Button>
-                            </Box>
-                        </>
-                    ) : (
-                        <>
-                            <IconButton
-                                aria-label="Focus"
-                                color="primary"
-                                disabled={isSubmitting}
-                                onClick={() => handleFocus(entry._id)}>
-                                <FocusIcon />
-                            </IconButton>
-                            <IconButton
-                                aria-label="Edit"
-                                color="edit"
-                                disabled={isSubmitting}
-                                onClick={() => handleEdit(entry._id)}
-                            >
-                                <EditIcon />
-                            </IconButton>
-                            <IconButton
-                                aria-label="Delete"
-                                color="danger"
-                                disabled={isSubmitting}
-                                onClick={() => handleDelete(entry._id)}
-                            >
-                                <DeleteIcon />
-                            </IconButton>
-                        </>
-                    )}
-                </Box>
-            ))}
+                                    <EditIcon />
+                                </IconButton>
+                                <IconButton
+                                    aria-label="Delete"
+                                    color="danger"
+                                    disabled={isSubmitting}
+                                    onClick={() => handleDelete(entry._id)}
+                                >
+                                    <DeleteIcon />
+                                </IconButton>
+                            </>
+                        )}
+                    </Box>
+                ))}
+            </Box>
         </Item>
     );
 }


### PR DESCRIPTION
This PR updates the index page to use MUI Box with maxHeight and auto overflow to make analysis, messages, and entries list scrollable. This arranges the components on the entries page in a more organized and easily accessible manner by preventing long lists of messages and entries from taking up the view of the entires page.