### PR TITLE
Add typewriter effect to analyses.

### DIFF
--- a/frontend/src/components/entries/Index.jsx
+++ b/frontend/src/components/entries/Index.jsx
@@ -23,6 +23,7 @@ export default function Entries() {
     const [enteringTitle, setEnteringTitle] = useState('');
     const [copiedJournalTitle, setCopiedJournalTitle] = useState('');
     const [validationError, setValidationError] = useState('');
+    const [typeWrittenId, setTypeWrittenId] = useState('');
 
     const entries = useEntries();
     const access = useAccess();
@@ -137,6 +138,8 @@ export default function Entries() {
                     focusedEntryId={focusedEntryId}
                     journalId={journalId}
                     setAllEntries={setAllEntries}
+                    setTypeWrittenId={setTypeWrittenId}
+                    typeWrittenId={typeWrittenId}
                 />}
             </Grid>
             <Grid item md={focusedEntryId ? 6 : 12} xs={12}>
@@ -144,6 +147,7 @@ export default function Entries() {
                     journalId={journalId}
                     setEntries={setAllEntries}
                     setFocusedEntryId={setFocusedEntryId}
+                    setTypeWrittenId={setTypeWrittenId}
                 />
                 {focusedEntryId && <Thoughts
                     allEntries={allEntries}
@@ -153,6 +157,7 @@ export default function Entries() {
                     setAllEntries={setAllEntries}
                     setEditedEntryId={setEditedEntryId}
                     setFocusedEntryId={setFocusedEntryId}
+                    setTypeWrittenId={setTypeWrittenId}
                 />}
             </Grid>
         </Grid>

--- a/frontend/src/components/entries/analysis/Analysis.jsx
+++ b/frontend/src/components/entries/analysis/Analysis.jsx
@@ -5,9 +5,13 @@ import Chat from './chat/Chat';
 
 import { Item } from '../../../styles/components';
 import { Update as UpdateIcon } from '@mui/icons-material';
-import { useEntries } from '../../../hooks/useEntries';
 
-export default function Analysis({ journalId, focusedEntryId, editedEntryId, setAllEntries }) {
+import typeWriter from '../../../../public/scripts/typeWriter'
+
+import { useEntries } from '../../../hooks/useEntries';
+import { v4 as uuid } from 'uuid';
+
+export default function Analysis({ journalId, focusedEntryId, editedEntryId, setAllEntries, typeWrittenId, setTypeWrittenId }) {
     const [focusedData, setFocusedData] = useState({});
     const [editedData, setEditedData] = useState('');
     const [editing, setEditing] = useState(false);
@@ -15,6 +19,7 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
     const [validationError, setValidationError] = useState('');
     const [regenerating, setRegenerating] = useState(false);
     const [chat, setChat] = useState({});
+    const [typedAnalysis, setTypedAnalysis] = useState('')
 
     const entries = useEntries();
 
@@ -36,13 +41,18 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
 
                 setChat(chatData);
 
+                setTypedAnalysis('');
+                if (typeWrittenId) {
+                    typeWriter(entryAnalysisData.analysis_content, setTypedAnalysis, 10);
+                }
+
             } catch (error) {
                 console.error(error);
             }
         };
 
         makeRequest();
-    }, [focusedEntryId, editedEntryId]);
+    }, [focusedEntryId, editedEntryId, typeWrittenId]);
 
     const handleSave = () => {
         if (!editedData.length) {
@@ -76,6 +86,9 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
                 setAllEntries(allEntries => allEntries.map(entry =>
                     entry._id === focusedEntryId ? { ...entryAnalysisData.entry } : entry
                 ));
+
+                // Set the entry to be typed
+                setTypeWrittenId(uuid());
 
             } catch (error) {
                 console.error(error);
@@ -125,6 +138,8 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
                     entry._id === focusedEntryId ? { ...response.entry } : entry
                 ));
 
+                // Random ID to trigger typeWriter if focusedEntryId is the same
+                setTypeWrittenId(uuid());
 
             } catch (error) {
                 console.error(error);
@@ -185,10 +200,9 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
                             </>
                         ) : (
                             <Typography variant="body2">
-                                {focusedData?.analysis_content}
+                                {typeWrittenId ? typedAnalysis : focusedData?.analysis_content}
                             </Typography>
-                        )
-                        }
+                        )}
                         <Tooltip title="Generate a new analysis.">
                             <Box display="flex" justifyContent="flex-end">
                                 <Button

--- a/frontend/src/components/entries/thoughts/Entry.jsx
+++ b/frontend/src/components/entries/thoughts/Entry.jsx
@@ -5,7 +5,7 @@ import { useEntries } from '../../../hooks/useEntries';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
-export default function Entry({ setEntries, setFocusedEntryId }) {
+export default function Entry({ setEntries, setFocusedEntryId, setTypeWrittenId }) {
     const [newEntry, setNewEntry] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [validationError, setValidationError] = useState('');
@@ -57,6 +57,9 @@ export default function Entry({ setEntries, setFocusedEntryId }) {
             setEntries((entries) => (
                 [data, ...entries]
             ));
+
+            // Set the entry to be typed
+            setTypeWrittenId(data._id);
         } catch (error) {
             console.error(error);
         } finally {

--- a/frontend/src/components/entries/thoughts/Thoughts.jsx
+++ b/frontend/src/components/entries/thoughts/Thoughts.jsx
@@ -8,7 +8,7 @@ import { useEntries } from '../../../hooks/useEntries';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
-export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, setFocusedEntryId, editedEntryId, setEditedEntryId }) {
+export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, setFocusedEntryId, editedEntryId, setEditedEntryId, setTypeWrittenId }) {
     const [editing, setEditing] = useState(false);
     const [editedData, setEditedData] = useState({
         title: '',
@@ -34,6 +34,9 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
         navigate(`/entries/${ entryId }`);
 
         setIsSubmitting(false);
+
+        // Stop typing animation on focus change
+        setTypeWrittenId('');
     }
 
     const handleEnterKeyPress = (event) => {
@@ -107,6 +110,9 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
             setEditedData({});
             setEditedEntryId('');
             setValidationError('');
+
+            // Set the entry to be typed
+            setTypeWrittenId(editedEntryId);
         } catch (error) {
             console.error(error);
         } finally {
@@ -144,6 +150,9 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
                 // Stay on the focused entry if filteredEntries is not empty
                 navigate(`/entries/${ filteredEntries.length ? focusedEntryId : '' }`);
             }
+
+            // Clear typing animation
+            setTypeWrittenId('');
         } catch (error) {
             console.error(error);
         } finally {


### PR DESCRIPTION
This PR adds the typewriter effect to the LLM analysis of the analysis component on the index (or Entries) page.

The typewriter effect is triggered whenever a new entry is made, when an entry is edited either through the Thoughts toolbar for each entry or click-to-edit, and on request for a new analysis.

Some minor style updates to center the journal title and remove excess margin are also implemented in this PR.