### PR TITLE
Add padding to analysis and chat sections.

### DIFF
--- a/frontend/src/components/entries/analysis/Analysis.jsx
+++ b/frontend/src/components/entries/analysis/Analysis.jsx
@@ -153,10 +153,10 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
 
     return (
         <Item>
-            <Typography variant="h2">
+            <Typography noWrap variant="h2">
                 {focusedData?.entry?.title}
             </Typography>
-            <Box sx={{ maxHeight: '45vh', overflow: 'auto' }}>
+            <Box sx={{ maxHeight: '45vh', overflow: 'auto', pt: '1em', pr: '1em' }}>
                 <Grid container spacing={2}>
                     <Grid item md={6} xs={12}>
                         {editing ? (

--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -9,7 +9,7 @@ export default function Chat({ journalId, focusedEntryId, chat, setChat }) {
             <InputLabel htmlFor="new-message" sx={{ color: 'inherit' }}>
                 <Typography variant="h2">Chat</Typography>
             </InputLabel >
-            {chat.messages && <Box sx={{ overflow: 'auto', flexGrow: 1, maxHeight: '50vh' }}>
+            {chat.messages && <Box sx={{ overflowY: 'auto', overflowX: 'hidden', flexGrow: 1, maxHeight: '50vh', pl: '1.6em', pr: '1.6em' }}>
                 <Messages
                     chat={chat}
                 />


### PR DESCRIPTION
This PR adds padding to ensure content is not cut off as noted in #52. Fits chat messages inside of their Box such that no horizontal scroll is needed. And adds noWrap to analysis title to reduce extra whitespace of newline added by h2 when it overflows to the next line.