### PR TITLE
Disable Thoughts toolbar for every analysis generation.

### DIFF
--- a/frontend/src/components/entries/Index.jsx
+++ b/frontend/src/components/entries/Index.jsx
@@ -24,6 +24,7 @@ export default function Entries() {
     const [copiedJournalTitle, setCopiedJournalTitle] = useState('');
     const [validationError, setValidationError] = useState('');
     const [typeWrittenId, setTypeWrittenId] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     const entries = useEntries();
     const access = useAccess();
@@ -138,6 +139,7 @@ export default function Entries() {
                     focusedEntryId={focusedEntryId}
                     journalId={journalId}
                     setAllEntries={setAllEntries}
+                    setIsSubmitting={setIsSubmitting}
                     setTypeWrittenId={setTypeWrittenId}
                     typeWrittenId={typeWrittenId}
                 />}
@@ -153,10 +155,12 @@ export default function Entries() {
                     allEntries={allEntries}
                     editedEntryId={editedEntryId}
                     focusedEntryId={focusedEntryId}
+                    isSubmitting={isSubmitting}
                     journalId={journalId}
                     setAllEntries={setAllEntries}
                     setEditedEntryId={setEditedEntryId}
                     setFocusedEntryId={setFocusedEntryId}
+                    setIsSubmitting={setIsSubmitting}
                     setTypeWrittenId={setTypeWrittenId}
                 />}
             </Grid>

--- a/frontend/src/components/entries/analysis/Analysis.jsx
+++ b/frontend/src/components/entries/analysis/Analysis.jsx
@@ -11,7 +11,7 @@ import typeWriter from '../../../../public/scripts/typeWriter'
 import { useEntries } from '../../../hooks/useEntries';
 import { v4 as uuid } from 'uuid';
 
-export default function Analysis({ journalId, focusedEntryId, editedEntryId, setAllEntries, typeWrittenId, setTypeWrittenId }) {
+export default function Analysis({ journalId, focusedEntryId, editedEntryId, setAllEntries, typeWrittenId, setTypeWrittenId, setIsSubmitting }) {
     const [focusedData, setFocusedData] = useState({});
     const [editedData, setEditedData] = useState('');
     const [editing, setEditing] = useState(false);
@@ -65,6 +65,7 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
         }
 
         setIsSaving(true);
+        setIsSubmitting(true);
 
         const makeRequest = async () => {
             try {
@@ -95,6 +96,7 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
             } finally {
                 setEditing(false);
                 setIsSaving(false);
+                setIsSubmitting(false);
             }
         }
 
@@ -107,6 +109,7 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
     }
 
     const handleOnBlur = () => {
+        setIsSubmitting(false);
         setEditing(false);
     }
 
@@ -123,6 +126,7 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
 
     const handleNewAnalysis = (event) => {
         event.preventDefault();
+        setIsSubmitting(true);
 
         const makeRequest = async () => {
             setRegenerating(true);
@@ -145,6 +149,7 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
                 console.error(error);
             } finally {
                 setRegenerating(false);
+                setIsSubmitting(false);
             }
         };
 

--- a/frontend/src/components/entries/thoughts/Thoughts.jsx
+++ b/frontend/src/components/entries/thoughts/Thoughts.jsx
@@ -8,7 +8,7 @@ import { useEntries } from '../../../hooks/useEntries';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
-export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, setFocusedEntryId, editedEntryId, setEditedEntryId, setTypeWrittenId }) {
+export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, setFocusedEntryId, editedEntryId, setEditedEntryId, setTypeWrittenId, isSubmitting, setIsSubmitting }) {
     const [editing, setEditing] = useState(false);
     const [editedData, setEditedData] = useState({
         title: '',
@@ -17,7 +17,6 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
         tags: [],
         privacy_settings: {},
     });
-    const [isSubmitting, setIsSubmitting] = useState(false);
     const [validationError, setValidationError] = useState('');
 
     const entries = useEntries();


### PR DESCRIPTION
This PR resolves #53. It pulls `isSubmitting` state variable in `Thoughts` component up to parent, `Index`, to be accessible in `Analysis` component and set true when a new analysis is being generated disabling the `Thoughts` toolbar. This makes it so that the user must wait for the analysis to be generated for an entry in order to navigate away.

This is a simple fix for v1. In later versions, idealistically the user would be able to navigate to another page or thought, and once their thought has be re-analyzed, they would be prompted with a link that would allow them to navigate back to the post for review. This gives them the option to do something else while they wait for their post.