### PR TITLE
Prevent state update on unmounted component in useEffect hook.

### DIFF
--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -55,23 +55,31 @@ export default function Home({ data }) {
     }, [isAnalysisTypingDone]);
 
     useEffect(() => {
-        return () => {
-            setTypedThought('');
-            setIsTypingDone(false);
+        let isMounted = true;
 
-            setTimeout(() => {
+        setTimeout(() => {
+            if (isMounted) {
                 typeWriter(cds[0].example, setTypedThought, 60)
                     .then(() => {
-                        setIsTypingDone(true);
-                        setTypedAnalysis('');
-                        typeWriter(cds[0].analysis, setTypedAnalysis, 10)
-                            .then(() => {
-                                setIsTypingDone(false);
-                                setIsAnalysisTypingDone(true)
-                            });
-                    }
-                    );
-            }, 1000);
+                        if (isMounted) {
+                            setIsTypingDone(true);
+                            setTypedAnalysis('');
+                            typeWriter(cds[0].analysis, setTypedAnalysis, 10)
+                                .then(() => {
+                                    if (isMounted) {
+                                        setIsTypingDone(false);
+                                        setIsAnalysisTypingDone(true)
+                                    }
+                                });
+                        }
+                    });
+            }
+        }, 1000);
+
+        return () => {
+            isMounted = false;
+            setTypedThought('');
+            setIsTypingDone(false);
         }
     }, []);
 


### PR DESCRIPTION
This pull request addresses a bug in the `Home` component where state updates were being attempted after the component had unmounted, leading to potential memory leaks and unexpected behavior.

The root cause of the issue was the asynchronous nature of the `setTimeout` and `typeWriter` functions inside the `useEffect` hook. In a production environment, the `Home` component could unmount before these asynchronous operations completed, leading to attempts to update the state of an unmounted component.

To fix this issue, I introduced a variable `isMounted` inside the `useEffect` hook. This variable is initially set to true when the component mounts. Before each state update inside the `setTimeout` and `typeWriter` functions, ( check if `isMounted` is still true, ensuring that we only update the state if the component is still mounted. In the cleanup function of the `useEffect` hook, I set `isMounted` to false, indicating that the component has unmounted.

This change ensures that we do not attempt to update the state after the `Home` component has unmounted, preventing potential memory leaks and unexpected behavior. It also aligns with React best practices for handling side effects in function components.