### PR TITLE
Connect to MongoDB Atlas in production.

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -26,7 +26,7 @@ if (process.env.NODE_ENV !== 'test') {
 
 // use cors middleware
 app.use(cors({
-  origin: [process.env.DEV_ORIGIN_LOCAL_URL, process.env.DEV_ORIGIN_PRIVATE_URL],
+  origin: [process.env.ORIGIN_SELF, process.env.ORIGIN_LOCAL, process.env.ORIGIN_PUBLIC, process.env.ORIGIN_DOMAIN],
   credentials: true
 }));
 

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -2,7 +2,7 @@ import { connect } from 'mongoose';
 
 export default async function connectDB(dbName) {
   // Define the local URI for development and testing
-  const localUri = `mongodb://localhost:27017/${ dbName }`;
+  const localUri = `${ process.env.MONGO_URI }/${ dbName }`;
 
   // Define the MongoDB Atlas URI for production
   const atlasUri = process.env.ATLAS_URI;

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,10 +1,28 @@
 import { connect } from 'mongoose';
 
 export default async function connectDB(dbName) {
-  // only connect if not testing otherwise connect to test db
-  if (process.env.NODE_ENV !== 'test') {
-    await connect(`mongodb://localhost:27017/${ dbName }`);
-  } else {
-    await connect(`mongodb://localhost:27017/${ dbName }-test`);
+  // Define the local URI for development and testing
+  const localUri = `mongodb://localhost:27017/${ dbName }`;
+
+  // Define the MongoDB Atlas URI for production
+  const atlasUri = process.env.ATLAS_URI;
+
+  try {
+    if (process.env.NODE_ENV === 'production') {
+      // Connect to MongoDB Atlas in production
+      await connect(atlasUri);
+      console.log('Connected to MongoDB Atlas');
+    } else if (process.env.NODE_ENV !== 'test') {
+      // Connect to the local MongoDB for development
+      await connect(localUri);
+      console.log(`Connected to local MongoDB: ${ localUri }`);
+    } else {
+      // Connect to the local test database
+      await connect(`mongodb://localhost:27017/${ dbName }-test`);
+      console.log(`Connected to local test MongoDB: ${ dbName }-test`);
+    }
+  } catch (err) {
+    console.error('Database connection error:', err);
+    process.exit(1);
   }
 }


### PR DESCRIPTION
This PR adds code to setup the database in production. The MongoDB Atlas service will be used when NODE_ENV is production, otherwise, a local MongoDB will be used in development and testing.