### PR TITLE
Launch HTTPS enabled server in production.

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,11 +1,30 @@
 import app from './src/app.js';
+import dotenv from 'dotenv';
 import express from 'express';
+import fs from 'fs';
+import https from 'https';
 
-const port = 3000;
-const server = express();
+const port = process.env.PORT;
 
-server.use(app);
+if (process.env.NODE_ENV !== 'production') {
+  const server = express();
 
-server.listen(port, () => {
-  console.log(`\nEXPRESS Listening on port ${ port }.`);
-});
+  server.use(app);
+
+  server.listen(port, () => {
+    console.log(`\nEXPRESS Listening on port ${ port }.`);
+  });
+} else {
+  dotenv.config();
+
+  const privateKey = fs.readFileSync(process.env.PRIVATE_KEY_PATH, 'utf8');
+  const certificate = fs.readFileSync(process.env.CERTIFICATE_PATH, 'utf8');
+  const ca = fs.readFileSync(process.env.CA_PATH, 'utf8');
+
+  const credentials = { key: privateKey, cert: certificate, ca };
+  const httpsServer = https.createServer(credentials, app);
+
+  httpsServer.listen(port, () => {
+    console.log(`\nHTTPS Listening on port ${ port }`);
+  });
+}

--- a/backend/src/models/user.js
+++ b/backend/src/models/user.js
@@ -174,9 +174,8 @@ userSchema.methods.sendPasswordResetEmail = async function (token) {
     }
   });
 
-  // TODO: Change this to the actual URL of the frontend app when deployed
   // Construct the password reset URL
-  const resetUrl = `${ process.env.DEV_ORIGIN_PRIVATE_URL }/reset-password?token=${ token }`;
+  const resetUrl = `${ process.env.RESET_PASSWORD_URL }/reset-password?token=${ token }`;
 
   // Email content
   const message = {


### PR DESCRIPTION
This PR establishes HTTPS in production.

Using conditionals, provided that the NODE_ENV is not production, the same http express server can be used in development or in a test environment. 

When the NODE_ENV is production, https is enabled using the https module and loads the ssl certificates. 

A new PORT environment variable is required in the backend to serve the app in development (e.g. port 3000) or to serve the app over https on the server, 8443.