### PR TITLE
Load environment variables at the very top of the application entry.

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,22 +1,20 @@
-import app from './src/app.js';
+/* eslint-disable sort-imports, import/first */
+
+// Load environment variables
 import dotenv from 'dotenv';
-import express from 'express';
+dotenv.config();
+
+import app from './src/app.js';
 import fs from 'fs';
 import https from 'https';
 
 const port = process.env.PORT;
 
 if (process.env.NODE_ENV !== 'production') {
-  const server = express();
-
-  server.use(app);
-
-  server.listen(port, () => {
+  app.listen(port, () => {
     console.log(`\nEXPRESS Listening on port ${ port }.`);
   });
 } else {
-  dotenv.config();
-
   const privateKey = fs.readFileSync(process.env.PRIVATE_KEY_PATH, 'utf8');
   const certificate = fs.readFileSync(process.env.CERTIFICATE_PATH, 'utf8');
   const ca = fs.readFileSync(process.env.CA_PATH, 'utf8');

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,17 +5,11 @@ import User from './models/user.js';
 
 import connectDB from './db.js';
 import cors from 'cors';
-import dotenv from 'dotenv';
 import express from 'express';
 import flash from 'connect-flash';
 import morgan from 'morgan';
 import passport from 'passport';
 import session from 'express-session';
-
-// load environment variables
-if (process.env.NODE_ENV !== 'production') {
-  dotenv.config();
-}
 
 const app = express();
 


### PR DESCRIPTION
This PR performs some refactoring at the entry point of the application.

Since it was decided to separate the app setup (app.js) and server launching (index.js) into separate files with index.js being the entry to the application, app requires being imported into index.js. 

Some refactoring was done to move the loading of environment variables to the top of index.js where it was previously loaded twice in both files depending on the node environment. 

Additionally, two express instances were created and then combined before spinning up the server, this has been changed to only one express instance returned from app.js on import.