### PR TITLE
Use redis as session store in production.

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "connect-flash": "^0.1.1",
+        "connect-redis": "^7.1.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -21,7 +22,8 @@
         "nodemailer": "^6.9.7",
         "passport": "^0.6.0",
         "passport-local": "^1.0.0",
-        "passport-local-mongoose": "^8.0.0"
+        "passport-local-mongoose": "^8.0.0",
+        "redis": "^4.6.12"
       },
       "devDependencies": {
         "@babel/core": "^7.23.3",
@@ -2815,6 +2817,64 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.13.tgz",
+      "integrity": "sha512-epkUM9D0Sdmt93/8Ozk43PNjLi36RZzG+d/T1Gdu5AI8jvghonTeLYV69WVWdilvFo+PYxbP0TZ0saMvr6nscQ==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.6.tgz",
+      "integrity": "sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.6.tgz",
+      "integrity": "sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.5.tgz",
+      "integrity": "sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -3728,6 +3788,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3792,6 +3860,17 @@
       "integrity": "sha512-2rcfELQt/ZMP+SM/pG8PyhJRaLKp+6Hk2IUBNkEit09X+vwn3QsAL3ZbYtxUn7NVPzbMTSLRDhqe0B/eh30RYA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/connect-redis": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.0.tgz",
+      "integrity": "sha512-UaqO1EirWjON2ENsyau7N5lbkrdYBpS6mYlXSeff/OYXsd6EGZ+SXSmNPoljL2PSua8fgjAEaldSA73PMZQ9Eg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "express-session": ">=1"
       }
     },
     "node_modules/content-disposition": {
@@ -5234,6 +5313,14 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/generaterr/-/generaterr-1.5.0.tgz",
       "integrity": "sha512-JgcGRv2yUKeboLvvNrq9Bm90P4iJBu7/vd5wSLYqMG5GJ6SxZT46LAAkMfNhQ+EK3jzC+cRBm7P8aUWYyphgcQ=="
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -8770,6 +8857,19 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/redis": {
+      "version": "4.6.12",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.12.tgz",
+      "integrity": "sha512-41Xuuko6P4uH4VPe5nE3BqXHB7a9lkFL0J29AlxKaIfD6eWO8VO/5PDF9ad2oS+mswMsfFxaM5DlE3tnXT+P8Q==",
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.5.13",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.6",
+        "@redis/search": "1.1.6",
+        "@redis/time-series": "1.0.5"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -12019,6 +12119,53 @@
         "fastq": "^1.6.0"
       }
     },
+    "@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "requires": {}
+    },
+    "@redis/client": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.13.tgz",
+      "integrity": "sha512-epkUM9D0Sdmt93/8Ozk43PNjLi36RZzG+d/T1Gdu5AI8jvghonTeLYV69WVWdilvFo+PYxbP0TZ0saMvr6nscQ==",
+      "requires": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "requires": {}
+    },
+    "@redis/json": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.6.tgz",
+      "integrity": "sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==",
+      "requires": {}
+    },
+    "@redis/search": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.6.tgz",
+      "integrity": "sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==",
+      "requires": {}
+    },
+    "@redis/time-series": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.5.tgz",
+      "integrity": "sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==",
+      "requires": {}
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -12726,6 +12873,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -12778,6 +12930,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
       "integrity": "sha512-2rcfELQt/ZMP+SM/pG8PyhJRaLKp+6Hk2IUBNkEit09X+vwn3QsAL3ZbYtxUn7NVPzbMTSLRDhqe0B/eh30RYA=="
+    },
+    "connect-redis": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.0.tgz",
+      "integrity": "sha512-UaqO1EirWjON2ENsyau7N5lbkrdYBpS6mYlXSeff/OYXsd6EGZ+SXSmNPoljL2PSua8fgjAEaldSA73PMZQ9Eg==",
+      "requires": {}
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -13853,6 +14011,11 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/generaterr/-/generaterr-1.5.0.tgz",
       "integrity": "sha512-JgcGRv2yUKeboLvvNrq9Bm90P4iJBu7/vd5wSLYqMG5GJ6SxZT46LAAkMfNhQ+EK3jzC+cRBm7P8aUWYyphgcQ=="
+    },
+    "generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -16420,6 +16583,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "redis": {
+      "version": "4.6.12",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.12.tgz",
+      "integrity": "sha512-41Xuuko6P4uH4VPe5nE3BqXHB7a9lkFL0J29AlxKaIfD6eWO8VO/5PDF9ad2oS+mswMsfFxaM5DlE3tnXT+P8Q==",
+      "requires": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.5.13",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.6",
+        "@redis/search": "1.1.6",
+        "@redis/time-series": "1.0.5"
+      }
     },
     "regenerate": {
       "version": "1.4.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "connect-flash": "^0.1.1",
+    "connect-redis": "^7.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
@@ -23,7 +24,8 @@
     "nodemailer": "^6.9.7",
     "passport": "^0.6.0",
     "passport-local": "^1.0.0",
-    "passport-local-mongoose": "^8.0.0"
+    "passport-local-mongoose": "^8.0.0",
+    "redis": "^4.6.12"
   },
   "devDependencies": {
     "@babel/core": "^7.23.3",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,6 +4,7 @@ import ExpressError from './utils/ExpressError.js';
 import User from './models/user.js';
 
 import connectDB from './db.js';
+import connectStore from './store.js';
 import cors from 'cors';
 import express from 'express';
 import flash from 'connect-flash';
@@ -29,6 +30,7 @@ app.use(express.json());
 
 // use session middleware
 app.use(session({
+  store: connectStore(process.env.NODE_ENV === 'production' ? 'redis' : 'memory'),
   secret: process.env.SESSION_SECRET,
   resave: false,
   saveUninitialized: false,

--- a/backend/src/store.js
+++ b/backend/src/store.js
@@ -1,0 +1,26 @@
+import RedisStore from 'connect-redis';
+import redis from 'redis';
+
+export default function connectStore(store) {
+  if (store === 'redis') {
+    // create redis client
+    const redisClient = redis.createClient({
+      host: process.env.REDIS_HOST,
+      port: process.env.REDIS_PORT
+    });
+
+    // connect to redis
+    redisClient.connect().catch(console.error);
+
+    // redis client events
+    redisClient.on('error', err => console.log(err));
+    redisClient.on('connect', () => console.log(`Connected to Redis: ${ process.env.REDIS_HOST }:${ process.env.REDIS_PORT }.`));
+
+    // create redis store
+    return new RedisStore({
+      client: redisClient
+    });
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
This PR updates the session store to use Redis in production.

The first commit does the following,
- Adds redis and connect-redis as dependencies.
- Creates store.js that connects to a session store based on the node environment using a connectStore function. 
- Adds the redis configuration to the connectStore function. 
- Requires additional environment variables, REDIS_HOST and REDIS_PORT.