### PR TITLE
Close beta testing to approved users.

### DIFF
--- a/backend/src/middleware/access.js
+++ b/backend/src/middleware/access.js
@@ -1,4 +1,5 @@
 import ExpressError from '../utils/ExpressError.js';
+import User from '../models/user.js';
 
 import jwt from 'jsonwebtoken';
 
@@ -26,5 +27,30 @@ export const isLoggedIn = (req, res, next) => {
     });
   } else {
     return next();
+  }
+};
+
+/**
+ * Request beta access.
+ */
+export const requestBetaAccess = async (req, res, next) => {
+  if (process.env.RELEASE_PHASE !== 'beta') return next();
+
+  const { fname, lname, email } = req.body;
+
+  try {
+    // Create a new user
+    const newUser = new User({ email, fname, lname });
+
+    // Send a confirmation email for the beta request
+    await newUser.sendBetaRequestConfirmationEmail(newUser.generateEmailVerificationToken());
+
+    // Save the new user
+    await newUser.save();
+
+    req.flash('info', 'A request for beta access has been sent to The CDJ Team. Please check your mailbox to verify your email. Once verified, a followup email will be sent when you are approved with a special link to complete your registration. Thank you for your interest in the app!');
+    res.status(200).json({ flash: req.flash() });
+  } catch (err) {
+    return next(new ExpressError('An error occurred while attempting to request beta access.', 500));
   }
 };

--- a/backend/src/middleware/access.js
+++ b/backend/src/middleware/access.js
@@ -40,17 +40,21 @@ export const requestBetaAccess = async (req, res, next) => {
 
   try {
     // Create a new user
-    const newUser = new User({ email, fname, lname });
-
-    // Send a confirmation email for the beta request
-    await newUser.sendBetaRequestConfirmationEmail(newUser.generateEmailVerificationToken());
+    const newUser = await new User({ email, fname, lname });
 
     // Save the new user
     await newUser.save();
 
+    // Send a confirmation email for the beta request
+    await newUser.sendBetaRequestConfirmationEmail(newUser.generateEmailVerificationToken());
+
     req.flash('info', 'A request for beta access has been sent to The CDJ Team. Please check your mailbox to verify your email. Once verified, a followup email will be sent when you are approved with a special link to complete your registration. Thank you for your interest in the app!');
     res.status(200).json({ flash: req.flash() });
   } catch (err) {
+    if (err?.code === 11000) {
+      return next(new ExpressError('Cannot request beta access at this time.', 400));
+    }
+
     return next(new ExpressError('An error occurred while attempting to request beta access.', 500));
   }
 };

--- a/backend/src/models/user.js
+++ b/backend/src/models/user.js
@@ -224,7 +224,7 @@ userSchema.methods.sendPasswordResetEmail = async function (token) {
     from: `"${ process.env.SMTP_NAME }" <${ process.env.SMTP_USER }>`, // Sender address
     to: this.email, // Recipient address (user's email)
     subject: 'Password Reset Request',
-    text: `You are receiving this email because you (or someone else) have requested the password be reset for your account.\n\nPlease click on the following link, or paste it into your browser to complete the process:\n\n${ resetUrl }\n\nIf you did not request this, please ignore this email and your password will remain unchanged.\n`
+    text: `Dear ${ this.fname },\n\nYou are receiving this email because you (or someone else) have requested the password be reset for your account.\n\nPlease click on the following link, or paste it into your browser to complete the process:\n\n${ resetUrl }\n\nIf you did not request this, please ignore this email and your password will remain unchanged.\n\nSincerely,\nThe CDJ Team\n`
   };
 
   // Send the email
@@ -247,7 +247,7 @@ userSchema.methods.sendPasswordResetConfirmationEmail = async function () {
     from: `"${ process.env.SMTP_NAME }" <${ process.env.SMTP_USER }>`, // Sender address
     to: this.email, // Recipient address (user's email)
     subject: 'Password Reset Confirmation',
-    text: 'Your password has been successfully reset.\n'
+    text: 'Your password has been successfully reset. You may now log in with this email address and your new password.\n\nSincerely,\nThe CDJ Team\n'
   };
 
   // Send the email

--- a/backend/src/routes/access/access.js
+++ b/backend/src/routes/access/access.js
@@ -39,4 +39,10 @@ router.route('/register')
 router.route('/verify-email')
   .post(catchAsync(controller.verifyEmail));
 
+router.route('/beta-approval')
+  .get(catchAsync(controller.betaApproval));
+
+router.route('/beta-denial')
+  .get(catchAsync(controller.betaDenial));
+
 export default router;

--- a/backend/src/routes/access/access.js
+++ b/backend/src/routes/access/access.js
@@ -1,4 +1,4 @@
-import { isAuthenticated, isLoggedIn } from '../../middleware/access.js';
+import { isAuthenticated, isLoggedIn, requestBetaAccess } from '../../middleware/access.js';
 import { validateAccount, validateLogin, validateNewPassword, validateRegistration } from '../../middleware/validation.js';
 
 import { Router } from 'express';
@@ -34,6 +34,9 @@ router.route('/logout')
   .get(isAuthenticated, controller.logout);
 
 router.route('/register')
-  .post(validateRegistration, catchAsync(controller.register));
+  .post(validateRegistration, catchAsync(requestBetaAccess), catchAsync(controller.register));
+
+router.route('/verify-email')
+  .post(catchAsync(controller.verifyEmail));
 
 export default router;

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -96,6 +96,14 @@ export default function Home({ data }) {
                     >
                         The Cognitive Distortion Journal
                     </Typography>
+                    <Typography
+                        align="center"
+                        className="title"
+                        justifyContent="center"
+                        variant="subtitle1"
+                    >
+                        {import.meta.env.VITE_RELEASE_PHASE}
+                    </Typography>
                 </Grid>
                 <Box sx={{ ml: '2em', mr: '2em', mb: '2em', width: '100%' }}>
                     {!typedAnalysis && <Fade in={true} timeout={2000}>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,6 @@
 import './index.css'
 
-import { Account, ForgotPassword, Login, Logout, Register, ResetPassword } from './routes/access';
+import { Account, ForgotPassword, Login, Logout, Register, ResetPassword, VerifyEmail } from './routes/access';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import ErrorPage from './components/utils/ErrorPage'
@@ -65,6 +65,10 @@ const router = createBrowserRouter([
         path: '/register',
         element: <Register />,
       },
+      {
+        path: '/verify-email',
+        element: <VerifyEmail />,
+      }
     ],
   },
 ]);

--- a/frontend/src/routes/access/index.js
+++ b/frontend/src/routes/access/index.js
@@ -4,3 +4,4 @@ export { default as Login } from './public/Login';
 export { default as Register } from './public/Register';
 export { default as ForgotPassword } from './public/ForgotPassword';
 export { default as ResetPassword } from './public/ResetPassword';
+export { default as VerifyEmail } from './public/VerifyEmail';

--- a/frontend/src/routes/access/public/VerifyEmail.jsx
+++ b/frontend/src/routes/access/public/VerifyEmail.jsx
@@ -1,0 +1,33 @@
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { useAccess } from '../../../hooks/useAccess';
+import { useEffect } from 'react';
+
+export default function VerifyEmail() {
+    const [searchParams] = useSearchParams();
+
+    const access = useAccess();
+    const navigate = useNavigate();
+    const token = searchParams.get('token');
+
+    useEffect(() => {
+        const verifyEmail = async () => {
+
+            await access(
+                '/verify-email',
+                'POST',
+                { 'Content-Type': 'application/json' },
+                { token },
+            )
+                .catch((error) => {
+                    console.error(error);
+                });
+        }
+
+        if (token) {
+            verifyEmail();
+        }
+
+        navigate('/login', { replace: true });
+    }, [])
+}


### PR DESCRIPTION
This PR establishes release phases. The initial commit sets up a beta user request route with email verification.

Specifically, if the release phase is beta, when a user registers they will be asked to verify their email and await a message with a special link to gain beta access through the `requestBetaAccess` middleware along the registration route. The `requestBetaAccess` middleware creates a new user without a password preventing the user from being able to login since passport is expecting a salt value. 

New fields are added to the User model for email verification that uses JWTs, `verifyEmailToken`, `verifyEmailExpires`, and `emailVerified`. A new `verify-email` route has been added to both the API and frontend router. The frontend simply makes a request to that access API endpoint where a `verifyEmail` controller sets the `emailVerified` User field to true. _An email must be valid in order to receive the email._ The client is then navigated to the `Login` page where they are flashed either a success or failure message.

Closing this PR will close issues #81 and #42 