### PR TITLE
Prevent backdoor login on beta request.

### DIFF
--- a/backend/src/controllers/access/access.js
+++ b/backend/src/controllers/access/access.js
@@ -309,6 +309,11 @@ export const forgotPassword = async (req, res, next) => {
     // If user doesn't exist, return error
     if (!user) return next(new ExpressError('Could not send recovery email.', 400));
 
+    // Check betaAccess if beta release phase is beta and user is not approved
+    if (process.env.RELEASE_PHASE === 'beta' && !user.betaAccess) {
+      return next(new ExpressError('You must be approved for beta access to reset your password.', 403));
+    }
+
     try {
       // Generate a password reset token
       const token = await user.generatePasswordResetToken();


### PR DESCRIPTION
This PR patches a security issue. A sus user might try to log in and get beta access by clicking Forgot Password. This patches that hole by checking if the user with the given email is pending approval. Previously a user that requests beta access could press Forgot Password and be sent a password reset link to establish a password necessary to log in effectively logging in through the backdoor.

The `email` of a user that request beta approval is stored in the database. If this `email` exists and the user does not have beta access by checking the `betaAccess` flag within the same model, when they try to click Forgot Password for a recovery email, the `next()` middleware is called which is the error handler sending back a a message that the user requires beta access to reset their password.