### PR TITLE
Enhanced User Interaction with Recent Thoughts in Analysis View

### DIFF
--- a/frontend/src/components/entries/thoughts/Thoughts.jsx
+++ b/frontend/src/components/entries/thoughts/Thoughts.jsx
@@ -188,24 +188,29 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
                             margin: '0 0 2em',
                         }}>
                         <Box
-                            sx={{
-                                display: 'flex',
-                            }}
+                            onClick={() => handleFocus(entry._id)}
+                            sx={{ cursor: 'pointer' }}
                         >
-                            <Typography
-                                sx={{ flex: 2 }}
-                                variant="body1"
+                            <Box
+                                sx={{
+                                    display: 'flex',
+                                }}
                             >
-                                {entry.title}
-                            </Typography>
-                            <Typography
-                                sx={{ flex: 1, lineHeight: '2.6em', textAlign: 'right' }}
-                                variant="caption"
-                            >
-                                {getReadableDate(entry.created_at)}
-                            </Typography>
+                                <Typography
+                                    sx={{ flex: 2 }}
+                                    variant="body1"
+                                >
+                                    {entry.title}
+                                </Typography>
+                                <Typography
+                                    sx={{ flex: 1, lineHeight: '2.6em', textAlign: 'right' }}
+                                    variant="caption"
+                                >
+                                    {getReadableDate(entry.created_at)}
+                                </Typography>
+                            </Box>
+                            <Typography noWrap variant="body2">{entry.content}</Typography>
                         </Box>
-                        <Typography noWrap variant="body2">{entry.content}</Typography>
                         {editing && editedEntryId === entry._id ? (
                             <>
                                 <TextField
@@ -246,13 +251,15 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
                             </>
                         ) : (
                             <>
-                                <IconButton
+                                {entry._id !== focusedEntryId && <IconButton
                                     aria-label="Focus"
                                     color="primary"
                                     disabled={isSubmitting}
-                                    onClick={() => handleFocus(entry._id)}>
+                                    onClick={() => handleFocus(entry._id)}
+                                >
                                     <FocusIcon />
                                 </IconButton>
+                                }
                                 <IconButton
                                     aria-label="Edit"
                                     color="edit"


### PR DESCRIPTION
## Overview
This PR introduces a user-friendly enhancement allowing users to focus on a recent thought by simply clicking on it in the analysis view. This feature streamlines the process of selecting and focusing on thoughts, making the user experience more intuitive and efficient.

## Changes
- **Clickable Thoughts for Focus**
  - Users can now click directly on a thought to focus it in the analysis view. This interaction mimics the functionality previously achieved through the 'Focus' button, offering a more direct and intuitive approach.
  
- **Focus Button Visibility**
  - When a recent thought is selected and in focus, the 'Focus' button is now hidden. This change serves as a visual cue to users, indicating that the thought is already in focus and the function of the button has been utilized.

<img width="828" alt="Screenshot 2024-01-21 at 8 10 28 PM" src="https://github.com/hiyaryan/the-cdj/assets/58452495/56a8a457-e419-4cba-a9fc-48caa1da8bdb">

## Impact
- **User Experience**: These changes simplify the user's interaction with the application, making the process of focusing on thoughts more straightforward and visually intuitive.
- **UI Clarity**: By removing the 'Focus' button when unnecessary, the UI becomes less cluttered, enhancing overall clarity and usability.

## Testing Steps
- Interact with the recent thoughts in the analysis view to ensure that clicking on a thought sets it into focus as expected.
- Observe the behavior of the 'Focus' button, ensuring it disappears when the corresponding thought is in focus and reappears when focus shifts.
