### PR TITLE
Add margin to top of click-to-edit thought TextField in analysis section.

### DIFF
--- a/frontend/src/components/entries/analysis/Analysis.jsx
+++ b/frontend/src/components/entries/analysis/Analysis.jsx
@@ -187,6 +187,7 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
                                 onBlur={handleOnBlur}
                                 onChange={handleEditing}
                                 onKeyDown={handleKeyPress}
+                                sx={{ mt: '0.5em' }}
                                 value={editedData}
                                 variant="outlined"
                             />


### PR DESCRIPTION
This PR resolves issue #96 where the helper text is partially out of view. Adding margin prevents the helper text from getting cut off as it slightly rises above the TextField out of frame of the Box containing it. Closes #96 