### PR TITLE
Add Tooltip to title.

### DIFF
--- a/frontend/src/components/entries/Index.jsx
+++ b/frontend/src/components/entries/Index.jsx
@@ -1,4 +1,4 @@
-import { Grid, TextField, Typography } from '@mui/material';
+import { Grid, TextField, Tooltip, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 import Analysis from './analysis/Analysis';
@@ -120,14 +120,16 @@ export default function Entries() {
                             variant="standard"
                         />
                     ) : (
-                        <Typography
-                            align="center"
-                            onClick={isEnteringTitle}
-                            sx={{ cursor: 'pointer' }}
-                            variant="h1"
-                        >
-                            {journalTitle}
-                        </Typography>
+                        <Tooltip title="Click to edit your title.">
+                            <Typography
+                                align="center"
+                                onClick={isEnteringTitle}
+                                sx={{ cursor: 'pointer' }}
+                                variant="h1"
+                            >
+                                {journalTitle}
+                            </Typography>
+                        </Tooltip>
                     )
                     }
                 </Item>


### PR DESCRIPTION
Hovering over title in Entries reveals a popup with a tip showing the user they may update their journal title.

<img width="653" alt="Screenshot 2024-01-24 at 1 36 44 PM" src="https://github.com/hiyaryan/the-cdj/assets/58452495/2bbc0dd3-f803-4301-a55b-030d3ab9d457">
