### PR TITLE
Add ability to collapse Recent Thoughts.

### DIFF
--- a/frontend/src/components/entries/thoughts/Thoughts.jsx
+++ b/frontend/src/components/entries/thoughts/Thoughts.jsx
@@ -1,7 +1,7 @@
 import './Thoughts.css'
 
-import { Box, Button, CircularProgress, Grid, IconButton, LinearProgress, TextField, Typography } from '@mui/material';
-import { Delete as DeleteIcon, Edit as EditIcon, AspectRatio as FocusIcon } from '@mui/icons-material';
+import { Box, Button, CircularProgress, Collapse, Grid, IconButton, LinearProgress, TextField, Typography } from '@mui/material';
+import { Delete as DeleteIcon, ArrowDropDown as DownIcon, Edit as EditIcon, AspectRatio as FocusIcon, ArrowDropUp as UpIcon } from '@mui/icons-material';
 
 import { Item } from '../../../styles/components';
 import { useEntries } from '../../../hooks/useEntries';
@@ -18,6 +18,7 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
         privacy_settings: {},
     });
     const [validationError, setValidationError] = useState('');
+    const [isCollapsed, setIsCollapsed] = useState(false);
 
     const entries = useEntries();
     const navigate = useNavigate();
@@ -169,6 +170,10 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
         return new Date(date).toLocaleDateString('en-US', options);
     }
 
+    const handleCollapse = () => {
+        setIsCollapsed(!isCollapsed);
+    }
+
     return (
         <Item>
             <Grid container>
@@ -176,111 +181,118 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
                     {!editing && isSubmitting && <CircularProgress color="edit" size={20} sx={{ mt: '25px', mr: '15px' }} />}
                 </Grid>
                 <Grid item>
-                    <Typography mt="-2em" variant="h2">Recent Thoughts</Typography>
+                    <Typography mt="-2em" onClick={handleCollapse} variant="h2">
+                        Recent Thoughts
+                        <IconButton aria-label="Collapse" color="primary" size="small">
+                            {isCollapsed ? <DownIcon /> : <UpIcon />}
+                        </IconButton>
+                    </Typography>
                 </Grid>
             </Grid>
-            <Box sx={{ height: '100vh', overflow: 'auto' }}>
-                {allEntries.map((entry) => (
-                    <Box
-                        className={entry._id === focusedEntryId ? 'focused' : ''}
-                        key={entry._id}
-                        sx={{
-                            margin: '0 0 2em',
-                        }}>
+            <Collapse in={!isCollapsed} timeout="auto" unmountOnExit>
+                <Box sx={{ height: '100vh', overflow: 'auto' }}>
+                    {allEntries.map((entry) => (
                         <Box
-                            onClick={() => handleFocus(entry._id)}
-                            sx={{ cursor: 'pointer' }}
-                        >
+                            className={entry._id === focusedEntryId ? 'focused' : ''}
+                            key={entry._id}
+                            sx={{
+                                margin: '0 0 2em',
+                            }}>
                             <Box
-                                sx={{
-                                    display: 'flex',
-                                }}
+                                onClick={() => handleFocus(entry._id)}
+                                sx={{ cursor: 'pointer' }}
                             >
-                                <Typography
-                                    sx={{ flex: 2 }}
-                                    variant="body1"
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                    }}
                                 >
-                                    {entry.title}
-                                </Typography>
-                                <Typography
-                                    sx={{ flex: 1, lineHeight: '2.6em', textAlign: 'right' }}
-                                    variant="caption"
-                                >
-                                    {getReadableDate(entry.created_at)}
-                                </Typography>
-                            </Box>
-                            <Typography noWrap variant="body2">{entry.content}</Typography>
-                        </Box>
-                        {editing && editedEntryId === entry._id ? (
-                            <>
-                                <TextField
-                                    autoFocus
-                                    disabled={isSubmitting}
-                                    error={Boolean(validationError)}
-                                    fullWidth
-                                    helperText={validationError}
-                                    label="Edit your thought."
-                                    maxRows={6}
-                                    minRows={3}
-                                    multiline
-                                    onChange={handleEditing}
-                                    onKeyDown={handleEnterKeyPress}
-                                    value={editedData.content}
-                                    variant="filled"
-                                />
-                                {isSubmitting && <LinearProgress />}
-                                <Box display="flex" justifyContent="flex-end" marginTop={2}>
-                                    <Button
-                                        color="primary"
-                                        disabled={Boolean(validationError) || isSubmitting}
-                                        onClick={handleSaveEdit}
-                                        variant="contained"
+                                    <Typography
+                                        sx={{ flex: 2 }}
+                                        variant="body1"
                                     >
-                                        Save
-                                    </Button>
-                                    <Button
-                                        color="cancel"
-                                        disabled={isSubmitting}
-                                        onClick={handleCancelEdit}
-                                        style={{ marginLeft: 8 }}
-                                        variant="contained"
+                                        {entry.title}
+                                    </Typography>
+                                    <Typography
+                                        sx={{ flex: 1, lineHeight: '2.6em', textAlign: 'right' }}
+                                        variant="caption"
                                     >
-                                        Cancel
-                                    </Button>
+                                        {getReadableDate(entry.created_at)}
+                                    </Typography>
                                 </Box>
-                            </>
-                        ) : (
-                            <>
-                                {entry._id !== focusedEntryId && <IconButton
-                                    aria-label="Focus"
-                                    color="primary"
-                                    disabled={isSubmitting}
-                                    onClick={() => handleFocus(entry._id)}
-                                >
-                                    <FocusIcon />
-                                </IconButton>
-                                }
-                                <IconButton
-                                    aria-label="Edit"
-                                    color="edit"
-                                    disabled={isSubmitting}
-                                    onClick={() => handleEdit(entry._id)}
-                                >
-                                    <EditIcon />
-                                </IconButton>
-                                <IconButton
-                                    aria-label="Delete"
-                                    color="danger"
-                                    disabled={isSubmitting}
-                                    onClick={() => handleDelete(entry._id)}
-                                >
-                                    <DeleteIcon />
-                                </IconButton>
-                            </>
-                        )}
-                    </Box>
-                ))}
-            </Box>
+                                <Typography noWrap variant="body2">{entry.content}</Typography>
+                            </Box>
+                            {editing && editedEntryId === entry._id ? (
+                                <>
+                                    <TextField
+                                        autoFocus
+                                        disabled={isSubmitting}
+                                        error={Boolean(validationError)}
+                                        fullWidth
+                                        helperText={validationError}
+                                        label="Edit your thought."
+                                        maxRows={6}
+                                        minRows={3}
+                                        multiline
+                                        onChange={handleEditing}
+                                        onKeyDown={handleEnterKeyPress}
+                                        value={editedData.content}
+                                        variant="filled"
+                                    />
+                                    {isSubmitting && <LinearProgress />}
+                                    <Box display="flex" justifyContent="flex-end" marginTop={2}>
+                                        <Button
+                                            color="primary"
+                                            disabled={Boolean(validationError) || isSubmitting}
+                                            onClick={handleSaveEdit}
+                                            variant="contained"
+                                        >
+                                            Save
+                                        </Button>
+                                        <Button
+                                            color="cancel"
+                                            disabled={isSubmitting}
+                                            onClick={handleCancelEdit}
+                                            style={{ marginLeft: 8 }}
+                                            variant="contained"
+                                        >
+                                            Cancel
+                                        </Button>
+                                    </Box>
+                                </>
+                            ) : (
+                                <>
+                                    {entry._id !== focusedEntryId && <IconButton
+                                        aria-label="Focus"
+                                        color="primary"
+                                        disabled={isSubmitting}
+                                        onClick={() => handleFocus(entry._id)}
+                                    >
+                                        <FocusIcon />
+                                    </IconButton>
+                                    }
+                                    <IconButton
+                                        aria-label="Edit"
+                                        color="edit"
+                                        disabled={isSubmitting}
+                                        onClick={() => handleEdit(entry._id)}
+                                    >
+                                        <EditIcon />
+                                    </IconButton>
+                                    <IconButton
+                                        aria-label="Delete"
+                                        color="danger"
+                                        disabled={isSubmitting}
+                                        onClick={() => handleDelete(entry._id)}
+                                    >
+                                        <DeleteIcon />
+                                    </IconButton>
+                                </>
+                            )}
+                        </Box>
+                    ))}
+                </Box>
+            </Collapse>
         </Item>
     );
 }

--- a/frontend/src/components/entries/thoughts/Thoughts.jsx
+++ b/frontend/src/components/entries/thoughts/Thoughts.jsx
@@ -1,6 +1,6 @@
 import './Thoughts.css'
 
-import { Box, Button, CircularProgress, Collapse, Grid, IconButton, LinearProgress, TextField, Typography } from '@mui/material';
+import { Box, Button, CircularProgress, Collapse, Divider, Grid, IconButton, LinearProgress, TextField, Typography } from '@mui/material';
 import { Delete as DeleteIcon, ArrowDropDown as DownIcon, Edit as EditIcon, AspectRatio as FocusIcon, ArrowDropUp as UpIcon } from '@mui/icons-material';
 
 import { Item } from '../../../styles/components';
@@ -189,6 +189,7 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
                     </Typography>
                 </Grid>
             </Grid>
+            {isCollapsed && <Divider fullWidth />}
             <Collapse in={!isCollapsed} timeout="auto" unmountOnExit>
                 <Box sx={{ height: '100vh', overflow: 'auto' }}>
                     {allEntries.map((entry) => (


### PR DESCRIPTION
Recent Thoughts may now be collpased with up and down arrows next to h2. This is done using MUI Collapse component and additional state variable `isCollapsed` which is set by clicking the MUI icon DropArrowUp or DrowArrowDown.

<img width="839" alt="Screenshot 2024-01-24 at 3 33 55 PM" src="https://github.com/hiyaryan/the-cdj/assets/58452495/4933d93a-4c6a-47cf-858e-ab2925b7e7c1">
Recent Thoughts not collapsed

<img width="839" alt="Screenshot 2024-01-24 at 3 34 05 PM" src="https://github.com/hiyaryan/the-cdj/assets/58452495/36f71370-f922-4361-93ae-ca77f81b8976">
Recent Thoughts collapsed