### PR TITLE
Implement Google Analytics integration in frontend.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^5.14.18",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-ga4": "^2.1.0",
         "react-router-dom": "^6.18.0",
         "uuid": "^9.0.1"
       },
@@ -3707,6 +3708,11 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7028,6 +7034,11 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "react-is": {
       "version": "16.13.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@mui/material": "^5.14.18",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-ga4": "^2.1.0",
     "react-router-dom": "^6.18.0",
     "uuid": "^9.0.1"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,7 +12,11 @@ import { Outlet } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import { theme } from './styles/theme.jsx'
 
+import { usePageTracking } from './hooks/usePageTracking';
+
 export default function App() {
+  usePageTracking();
+
   return (
     <>
       <CssBaseline />

--- a/frontend/src/hooks/usePageTracking.jsx
+++ b/frontend/src/hooks/usePageTracking.jsx
@@ -1,0 +1,12 @@
+import ReactGA from 'react-ga4';
+
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export function usePageTracking() {
+    const location = useLocation();
+
+    useEffect(() => {
+        ReactGA.send({ hitType: 'pageview', page: location.pathname });
+    }, [location]);
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -11,7 +11,12 @@ import Home from './routes/Home';
 import Index from './routes/entries';
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import ReactGA from 'react-ga4';
 import Root from './routes/root';
+
+if (import.meta.env.VITE_NODE_ENV === 'production') {
+  ReactGA.initialize(import.meta.env.VITE_GA_TRACKING_ID);
+}
 
 const router = createBrowserRouter([
   {


### PR DESCRIPTION
This PR introduces Google Analytics to the app.

It adds `react-ga4` package as dependencym implements a `usePageTracking` hook within the `App` component responsible for tracking page views and initializes the ReactGA module, which is configured only to initialize in the production environment done using new `VITE_NODE_ENV` and `VITE_GA_TRACKING_ID` environment variables.