### PR TITLE
Remove dead space from Recent Thoughts.

### DIFF
--- a/frontend/src/components/entries/thoughts/Thoughts.jsx
+++ b/frontend/src/components/entries/thoughts/Thoughts.jsx
@@ -191,7 +191,7 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
             </Grid>
             {isCollapsed && <Divider fullWidth />}
             <Collapse in={!isCollapsed} timeout="auto" unmountOnExit>
-                <Box sx={{ height: '100vh', overflow: 'auto' }}>
+                <Box sx={{ maxHeight: '100vh', overflow: 'auto' }}>
                     {allEntries.map((entry) => (
                         <Box
                             className={entry._id === focusedEntryId ? 'focused' : ''}


### PR DESCRIPTION
Recent thoughts contained a substantial amount of dead space due to height being set. To correct this maxHeight is used instead. This PR closes #104 