### PR TITLE
Add collapse to chat messages.

### DIFF
--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -31,7 +31,11 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
 
     const alignChat = () => {
         lastMessageRef.current.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
-        alignChatRef.current.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
+
+        // Ensure previous scroll has finished
+        setTimeout(() => {
+            alignChatRef.current.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
+        }, 50);
     }
 
     return (

--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -1,4 +1,5 @@
-import { Box, InputLabel, Typography } from '@mui/material';
+import { Box, Collapse, Divider, IconButton, InputLabel, Typography } from '@mui/material';
+import { ArrowDropDown as DownIcon, ArrowDropUp as UpIcon } from '@mui/icons-material';
 import { useEffect, useRef, useState } from 'react';
 
 import ChatEntry from './ChatEntry';
@@ -10,6 +11,7 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
     const alignChatRef = useRef(null);
 
     const [hasSent, setHasSent] = useState(false);
+    const [isCollapsed, setIsCollapsed] = useState(false);
 
     useEffect(() => {
         if (messagesEndRef.current) {
@@ -22,6 +24,10 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
         }
     }, [chat]);
 
+    const handleCollapse = () => {
+        setIsCollapsed(!isCollapsed);
+    }
+
     return (
         <Box
             ref={alignChatRef}
@@ -30,35 +36,43 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
             <InputLabel
                 htmlFor="new-message"
                 sx={{ color: 'inherit' }}>
-                <Typography variant="h2">Chat</Typography>
+                <Typography onClick={handleCollapse} variant="h2" >
+                    Chat
+                    <IconButton aria-label="Collapse" color="primary" size="small">
+                        {isCollapsed ? <DownIcon /> : <UpIcon />}
+                    </IconButton>
+                </Typography>
             </InputLabel >
-            <Typography mb="1.5em" variant="body1">
+            <Typography mb="1.5em" onClick={handleCollapse} variant="body1">
                 Talk about <i>{focusedData?.entry?.title}</i>.
             </Typography>
-            {chat.messages &&
-                <Box
-                    ref={messagesEndRef}
-                    sx={{
-                        overflowY: 'auto',
-                        overflowX: 'hidden',
-                        flexGrow: 1,
-                        maxHeight: '50vh',
-                        pl: '1.6em',
-                        pr: '1.6em'
-                    }}>
-                    <Messages
-                        chat={chat}
-                        lastMessageRef={lastMessageRef}
-                        setHasSent={setHasSent}
-                    />
-                </Box>}
-            <ChatEntry
-                chat={chat}
-                focusedEntryId={focusedEntryId}
-                journalId={journalId}
-                setChat={setChat}
-                setHasSent={setHasSent}
-            />
+            {isCollapsed && <Divider />}
+            <Collapse in={!isCollapsed} timeout="auto" unmountOnExit>
+                {chat.messages &&
+                    <Box
+                        ref={messagesEndRef}
+                        sx={{
+                            overflowY: 'auto',
+                            overflowX: 'hidden',
+                            flexGrow: 1,
+                            maxHeight: '50vh',
+                            pl: '1.6em',
+                            pr: '1.6em'
+                        }}>
+                        <Messages
+                            chat={chat}
+                            lastMessageRef={lastMessageRef}
+                            setHasSent={setHasSent}
+                        />
+                    </Box>}
+                <ChatEntry
+                    chat={chat}
+                    focusedEntryId={focusedEntryId}
+                    journalId={journalId}
+                    setChat={setChat}
+                    setHasSent={setHasSent}
+                />
+            </Collapse>
         </Box>
     )
 }

--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -12,20 +12,26 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
 
     const [hasSent, setHasSent] = useState(false);
     const [isCollapsed, setIsCollapsed] = useState(false);
+    const [isFocused, setIsFocused] = useState(false);
 
     useEffect(() => {
         if (messagesEndRef.current) {
-            if (hasSent) {
-                lastMessageRef.current.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
-                alignChatRef.current.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
-            } else {
-                messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
-            }
+            if (hasSent) alignChat();
+            else messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
         }
     }, [chat]);
 
+    useEffect(() => {
+        if (isFocused) alignChat();
+    }, [isFocused]);
+
     const handleCollapse = () => {
         setIsCollapsed(!isCollapsed);
+    }
+
+    const alignChat = () => {
+        lastMessageRef.current.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
+        alignChatRef.current.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
     }
 
     return (
@@ -71,6 +77,7 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
                     journalId={journalId}
                     setChat={setChat}
                     setHasSent={setHasSent}
+                    setIsFocused={setIsFocused}
                 />
             </Collapse>
         </Box>

--- a/frontend/src/components/entries/analysis/chat/ChatEntry.jsx
+++ b/frontend/src/components/entries/analysis/chat/ChatEntry.jsx
@@ -4,7 +4,7 @@ import { Send as SendIcon } from '@mui/icons-material';
 import { useEntries } from '../../../../hooks/useEntries';
 import { useState } from 'react';
 
-export default function ChatEntry({ focusedEntryId, chat, setChat, setHasSent }) {
+export default function ChatEntry({ focusedEntryId, chat, setChat, setHasSent, setIsFocused }) {
     const [newChat, setNewChat] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [validationError, setValidationError] = useState('');
@@ -81,7 +81,9 @@ export default function ChatEntry({ focusedEntryId, chat, setChat, setHasSent })
                     maxRows={6}
                     minRows={3}
                     multiline
+                    onBlur={() => setIsFocused(false)}
                     onChange={handleNewChatChange}
+                    onFocus={() => setIsFocused(true)}
                     onKeyDown={handleEnterKeyPress}
                     value={newChat}
                     variant="filled"


### PR DESCRIPTION
This PR does the same to Chat like it does to Recent Thoughts in #102. It adds the ability to collapse the chat messages making it easier to navigate on smaller views.

#### Not collapsed
<img width="548" alt="Screenshot 2024-01-25 at 4 09 13 PM" src="https://github.com/hiyaryan/the-cdj/assets/58452495/eed4e200-eb5f-407d-9c8a-63dd78ad2ac1">

#### Collapsed
<img width="554" alt="Screenshot 2024-01-25 at 4 09 19 PM" src="https://github.com/hiyaryan/the-cdj/assets/58452495/c663f341-1c66-403f-9437-4db583c44dfe">


