### PR TITLE
Ensure most recent messages are shown when Chat is uncollapsed.

### DIFF
--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -19,7 +19,7 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
             if (hasSent) alignChat();
             else messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
         }
-    }, [chat]);
+    }, [chat, isCollapsed]);
 
     useEffect(() => {
         if (isFocused) alignChat();


### PR DESCRIPTION
Adds isCollapsed to useEffect to ensure that when Chat is uncollapsed the most recent messages are scrolled into view. Without this, the messages are scroll to the top.