### PR TITLE
Ensure Chat label focuses on ChatEntry TextField when clicked.

### DIFF
--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -46,9 +46,9 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
             <InputLabel
                 htmlFor="new-message"
                 sx={{ color: 'inherit' }}>
-                <Typography onClick={handleCollapse} variant="h2" >
+                <Typography variant="h2" >
                     Chat
-                    <IconButton aria-label="Collapse" color="primary" size="small">
+                    <IconButton aria-label="Collapse" color="primary" onClick={handleCollapse} size="small">
                         {isCollapsed ? <DownIcon /> : <UpIcon />}
                     </IconButton>
                 </Typography>

--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -45,7 +45,8 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
         >
             <InputLabel
                 htmlFor="new-message"
-                sx={{ color: 'inherit' }}>
+                sx={{ color: 'inherit' }}
+            >
                 <Typography variant="h2" >
                     Chat
                     <IconButton aria-label="Collapse" color="primary" onClick={handleCollapse} size="small">
@@ -53,9 +54,14 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
                     </IconButton>
                 </Typography>
             </InputLabel >
-            <Typography mb="1.5em" onClick={handleCollapse} variant="body1">
-                Talk about <i>{focusedData?.entry?.title}</i>.
-            </Typography>
+            <InputLabel
+                htmlFor="new-message"
+                sx={{ color: 'inherit' }}
+            >
+                <Typography mb="1.5em" variant="body1">
+                    Talk about <i>{focusedData?.entry?.title}</i>.
+                </Typography>
+            </InputLabel>
             {isCollapsed && <Divider />}
             <Collapse in={!isCollapsed} timeout="auto" unmountOnExit>
                 {chat.messages &&


### PR DESCRIPTION
The Chat label should focus on the ChatEntry TextField when clicked. Currently, it collapses the Chat view when clicked, this is not normal behavior. This PR moves the onClicked only to the collapse button.