### PR TITLE
Fix TypeError and scroll behavior.

### DIFF
--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -29,8 +29,19 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
         setIsCollapsed(!isCollapsed);
     }
 
+    const isElementInView = (el) => {
+        const rect = el.getBoundingClientRect();
+        return (
+            rect.top >= 0 &&
+            rect.left >= 0 &&
+            rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+            rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+        );
+    }
+
     const alignChat = () => {
-        lastMessageRef.current.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
+        if (lastMessageRef.current && !isElementInView(lastMessageRef.current))
+            lastMessageRef.current.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
 
         // Ensure previous scroll has finished
         setTimeout(() => {


### PR DESCRIPTION
This PR closes #111. It does this by scrolling to the last message in the chat box only if there is a message to reference and only if the existing last message is not in view.