### PR TITLE
Reduce single Entry API calls to one.

### DIFF
--- a/backend/src/controllers/entry/entry.js
+++ b/backend/src/controllers/entry/entry.js
@@ -70,14 +70,21 @@ export const createEntry = async (req, res, next) => {
 };
 
 /**
- * Get an entry by ID.
+ * Get an entry and all associated documents by ID.
  */
 export const getAnEntry = async (req, res) => {
   const { entryId } = req.params;
 
-  const entry = await Entry.findById(entryId);
+  try {
+    const entry = await Entry.findById(entryId);
+    const analysis = await EntryAnalysis.findOne({ entry: entryId });
+    const chat = await EntryConversation.findOne({ entry: entryId });
 
-  res.status(200).json(entry);
+    res.status(200).json({ entry, analysis, chat });
+  } catch (err) {
+    req.flash('info', err.message);
+    return next(err);
+  }
 };
 
 /**

--- a/backend/src/controllers/entry/entry.js
+++ b/backend/src/controllers/entry/entry.js
@@ -44,6 +44,9 @@ export const createEntry = async (req, res, next) => {
     const newEntry = new Entry({ journal: journalId, ...entryData });
     const newAnalysis = new EntryAnalysis({ entry: newEntry._id, analysis_content: entryData.analysis_content });
 
+    // Associate the entry with the analysis
+    newEntry.analysis = newAnalysis._id;
+
     // Get the analysis content for the entry
     try {
       const response = await newAnalysis.getAnalysisContent(journal.config, newEntry.content);
@@ -76,11 +79,9 @@ export const getAnEntry = async (req, res) => {
   const { entryId } = req.params;
 
   try {
-    const entry = await Entry.findById(entryId);
-    const analysis = await EntryAnalysis.findOne({ entry: entryId });
-    const chat = await EntryConversation.findOne({ entry: entryId });
+    const entry = await Entry.findById(entryId).populate('analysis conversation');
 
-    res.status(200).json({ entry, analysis, chat });
+    res.status(200).json(entry);
   } catch (err) {
     req.flash('info', err.message);
     return next(err);
@@ -260,11 +261,15 @@ export const createEntryConversation = async (req, res, next) => {
   // Get the config from the journal
   const journal = await Journal.findById(journalId);
 
-  // Get the analysis associated with the entry
-  const analysis = await EntryAnalysis.findOne({ entry: entryId });
+  // Get an entry with the analysis
+  const entry = await Entry.findById(entryId).populate('analysis');
+
+  // Associate the conversation with the entry
+  entry.conversation = newConversation._id;
+  await entry.save();
 
   try {
-    const llmResponse = await newConversation.getChatContent(journal.config, analysis._id, messageData.messages[0].message_content);
+    const llmResponse = await newConversation.getChatContent(journal.config, entry.analysis._id, messageData.messages[0].message_content);
 
     // If the chat is not empty, update the llm_response
     if (llmResponse) {

--- a/backend/src/models/entry/entry.js
+++ b/backend/src/models/entry/entry.js
@@ -12,7 +12,9 @@ const entrySchema = new Schema({
   privacy_settings: {
     public: { type: Boolean, default: false },
     shared_with: [{ type: Schema.Types.ObjectId, ref: 'User' }]
-  }
+  },
+  analysis: { type: Schema.Types.ObjectId, ref: 'EntryAnalysis' },
+  conversation: { type: Schema.Types.ObjectId, ref: 'EntryConversation' }
 });
 
 entrySchema.statics.joi = Joi.object({

--- a/frontend/src/components/entries/analysis/Analysis.jsx
+++ b/frontend/src/components/entries/analysis/Analysis.jsx
@@ -35,11 +35,11 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
                 const entryData = await entries(`/${ focusedEntryId }`, 'GET');
 
                 // Data displayed in this component
-                setFocusedData({ entry: entryData.entry, analysis_content: entryData.analysis.analysis_content });
-                setEditedData(entryData.entry.content);
+                setFocusedData(entryData);
+                setEditedData(entryData.content);
 
                 // Render child Chat component
-                setChat(entryData.chat?.messages ? entryData.chat : {});
+                setChat(entryData.conversation?.messages ? entryData.conversation : {});
 
                 setTypedAnalysis('');
                 if (typeWrittenId) {
@@ -170,7 +170,7 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
     return (
         <Item>
             <Typography lineHeight="2em" mb="0.5em" variant="h2">
-                {focusedData?.entry?.title}
+                {focusedData?.title}
             </Typography>
             <Box sx={{ maxHeight: '45vh', overflow: 'auto', pr: '1em' }}>
                 <Grid container spacing={2}>
@@ -198,7 +198,7 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
                                     sx={{ cursor: 'pointer' }}
                                     variant="body1"
                                 >
-                                    {focusedData?.entry?.content}
+                                    {focusedData?.content}
                                 </Typography>
                             </Tooltip>
                         )}
@@ -217,7 +217,7 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
                             </>
                         ) : (
                             <Typography variant="body2">
-                                {typeWrittenId ? typedAnalysis : focusedData?.analysis_content}
+                                {typeWrittenId ? typedAnalysis : focusedData?.analysis?.analysis_content}
                             </Typography>
                         )}
                         <Tooltip title="Generate a new analysis.">

--- a/frontend/src/components/entries/analysis/Analysis.jsx
+++ b/frontend/src/components/entries/analysis/Analysis.jsx
@@ -32,18 +32,18 @@ export default function Analysis({ journalId, focusedEntryId, editedEntryId, set
                     return
                 }
 
-                const entryAnalysisData = await entries(`/${ focusedEntryId }/analysis`, 'GET');
+                const entryData = await entries(`/${ focusedEntryId }`, 'GET');
 
-                setFocusedData(entryAnalysisData);
-                setEditedData(entryAnalysisData.entry.content);
+                // Data displayed in this component
+                setFocusedData({ entry: entryData.entry, analysis_content: entryData.analysis.analysis_content });
+                setEditedData(entryData.entry.content);
 
-                const chatData = await entries(`/${ focusedEntryId }/chat`, 'GET');
-
-                setChat(chatData);
+                // Render child Chat component
+                setChat(entryData.chat?.messages ? entryData.chat : {});
 
                 setTypedAnalysis('');
                 if (typeWrittenId) {
-                    typeWriter(entryAnalysisData.analysis_content, setTypedAnalysis, 10);
+                    typeWriter(entryData.analysis?.analysis_content, setTypedAnalysis, 10);
                 }
 
             } catch (error) {

--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -69,7 +69,7 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
                 sx={{ color: 'inherit' }}
             >
                 <Typography mb="1.5em" variant="body1">
-                    Talk about <i>{focusedData?.entry?.title}</i>.
+                    Talk about <i>{focusedData?.title}</i>.
                 </Typography>
             </InputLabel>
             {isCollapsed && <Divider />}

--- a/frontend/src/components/entries/thoughts/Thoughts.jsx
+++ b/frontend/src/components/entries/thoughts/Thoughts.jsx
@@ -51,8 +51,9 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
             const entryData = await entries(`/${ entryId }`, 'GET');
 
             setEditing(true);
-            setEditedData({ ...entryData.entry });
+            setEditedData(entryData);
             setEditedEntryId(entryId);
+            setTypeWrittenId('');
         } catch (error) {
             console.error(error);
         }
@@ -83,7 +84,7 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
                 `/${ editedEntryId }`,
                 'PUT',
                 { 'Content-Type': 'application/json' },
-                editedData
+                { content: editedData.content }
             );
 
             // Update the entries state with the edited data

--- a/frontend/src/components/entries/thoughts/Thoughts.jsx
+++ b/frontend/src/components/entries/thoughts/Thoughts.jsx
@@ -10,13 +10,7 @@ import { useState } from 'react';
 
 export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, setFocusedEntryId, editedEntryId, setEditedEntryId, setTypeWrittenId, isSubmitting, setIsSubmitting }) {
     const [editing, setEditing] = useState(false);
-    const [editedData, setEditedData] = useState({
-        title: '',
-        content: '',
-        mood: '',
-        tags: [],
-        privacy_settings: {},
-    });
+    const [editedData, setEditedData] = useState({});
     const [validationError, setValidationError] = useState('');
     const [isCollapsed, setIsCollapsed] = useState(false);
 
@@ -57,13 +51,7 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
             const entryData = await entries(`/${ entryId }`, 'GET');
 
             setEditing(true);
-            setEditedData({
-                title: entryData.title,
-                content: entryData.content,
-                mood: entryData.mood,
-                tags: entryData.tags,
-                privacy_settings: entryData.privacy_settings,
-            });
+            setEditedData({ ...entryData.entry });
             setEditedEntryId(entryId);
         } catch (error) {
             console.error(error);


### PR DESCRIPTION
This PR updates the resources returned for the API endpoint to view a single entry returning all associated documents. These changes improve the scalability of the app by making only one API call to the updated endpoint in the Analysis component. These changes brought updates to how the retrieved data structure is inserted into the components state variables. This also required updating how the Thoughts component inserts the data retrieved from the same endpoint.

The endpoint has been updated from making one db query on two separate API calls to making three on one. This could be reduced to two queries by populating the entry associated with the Analysis. However, a better design would be to insert the IDs of the associated documents on the entry  reducing the query made to one.