### PR TITLE
Make Chat box scroll into view on send.

### DIFF
--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -19,7 +19,7 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
             if (hasSent) alignChat();
             else messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
         }
-    }, [chat, isCollapsed]);
+    }, [chat, isCollapsed, hasSent]);
 
     useEffect(() => {
         if (isFocused) alignChat();


### PR DESCRIPTION
This PR patches a ux inconvenience where the chat box doesn't put in view the most recent message after retrieving a new one. This PR fixes it my adding hasSent to useEffect in the Chat component.