### PR TITLE
Wrap chat instructions and adjust label functionality.

### DIFF
--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -64,14 +64,11 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
                     {isCollapsed ? <DownIcon /> : <UpIcon />}
                 </IconButton>
             </Box>
-            <InputLabel
-                htmlFor="new-message"
-                sx={{ color: 'inherit' }}
-            >
-                <Typography mb="1.5em" variant="body1">
+            <Typography mb="1.5em" variant="body1">
+                <label htmlFor="new-message" style={{ cursor: 'pointer' }}>
                     Talk about <i>{focusedData?.title}</i>.
-                </Typography>
-            </InputLabel>
+                </label>
+            </Typography>
             {isCollapsed && <Divider />}
             <Collapse in={!isCollapsed} timeout="auto" unmountOnExit>
                 {chat.messages &&

--- a/frontend/src/components/entries/analysis/chat/Chat.jsx
+++ b/frontend/src/components/entries/analysis/chat/Chat.jsx
@@ -55,11 +55,9 @@ export default function Chat({ journalId, focusedEntryId, focusedData, chat, set
             sx={{ display: 'flex', flexDirection: 'column' }}
         >
             <Box alignItems="center" display="flex">
-                <InputLabel htmlFor="new-message" sx={{ color: 'inherit', display: 'flex', alignItems: 'center' }}>
-                    <Typography component="span" variant="h2">
-                        Chat
-                    </Typography>
-                </InputLabel>
+                <Typography onClick={handleCollapse} sx={{ cursor: 'pointer' }} variant="h2">
+                    Chat
+                </Typography>
                 <IconButton aria-label="Collapse" color="primary" onClick={handleCollapse} size="small">
                     {isCollapsed ? <DownIcon /> : <UpIcon />}
                 </IconButton>

--- a/frontend/src/components/entries/thoughts/Thoughts.jsx
+++ b/frontend/src/components/entries/thoughts/Thoughts.jsx
@@ -170,7 +170,7 @@ export default function Thoughts({ allEntries, setAllEntries, focusedEntryId, se
                     {!editing && isSubmitting && <CircularProgress color="edit" size={20} sx={{ mt: '25px', mr: '15px' }} />}
                 </Grid>
                 <Grid item>
-                    <Typography mt="-2em" onClick={handleCollapse} variant="h2">
+                    <Typography onClick={handleCollapse} sx={{ cursor: 'pointer', mt: '-2em' }} variant="h2">
                         Recent Thoughts
                         <IconButton aria-label="Collapse" color="primary" size="small">
                             {isCollapsed ? <DownIcon /> : <UpIcon />}


### PR DESCRIPTION
This PR makes the user experience more intuitive and smooth. It wraps the Chat instructions while keeping the label functionality of focusing on the `TextField`, provided Chat is not collapsed. `InputLabel` does not allow wrapping so it has been replaced with a basic html `label`. The Chat `h2` InputLabel has been removed changing its behavior to have only collapsing functionality like Recent Thoughts `h2` (cursor updated to pointer) when clicked.