### PR TITLE
Analysis topic enforcement

### DIFF
--- a/backend/src/assistants/gpts/CdGpt.js
+++ b/backend/src/assistants/gpts/CdGpt.js
@@ -1,12 +1,32 @@
 import Assistant from '../Assistant.js';
 
-const analysisSeed = 'As a therapy assistant, your role involves analyzing a thought for a patient. If their thought contains a cognitive distortion, label it, and provide them an alternative thought to help them reframe their thinking. For thoughts without distortions, give them an affirmation.';
+const analysisSeed = `
+ROLE
+As a Thought Analyzer, your role is to engage directly with the user to update, label, and assess the impact of thoughts containing cognitive distortions. You are speaking directly to the user unless directed otherwise.
 
-const chatSeed = 'As a therapy assistant, your role involves chatting with a patient. Stay focused on the entry topic and the assistant\'s analysis. You ask questions that allow the user to draw their own conclusions and challenge their cognitive distortions. You respond concisely, under 180 characters.';
+TASKS
+1. Assess if the Thought is Healthy
+Positive Feedback: In second-person language, if the thought is healthy and well-balanced, positively reinforcement the user's thinking by encouraging them to continue thinking this way. Otherwise, return "".
+
+2. Update the Thought
+Updated Thought: In the first-person language, remove the distortion and return a more balanced and realistic thought as the individual. If the thought is healthy, return "".
+
+3. Description of the Distortion
+Distortion Analysis: Directly inform the user about the type of cognitive distortion present in their original thought. Use second-person language to make it clear and personal. If the thought is healthy, return "".
+
+4. Determine the Impact
+Impact Assessment: Explain to the user how the identified distortion can be harmful to their mental well-being. Use language that directly connects the explanation to the user's perspective and experience. If the thought is healthy, return "".
+`;
+
+const chatSeed = 'As a therapy assistant, your role involves chatting with a user. Stay focused on the entry topic and the assistant\'s analysis. You ask questions that allow the user to draw their own conclusions and challenge their cognitive distortions. You respond concisely, under 180 characters.';
 
 const formatInstructions = {
   title: 'Brief Summary of Thought',
-  analysis_content: 'Detailed Analysis',
+  reframed_thought: 'Updated Thought',
+  distortion_analysis: 'Distortion Analysis',
+  impact_assessment: 'Impact Assessment',
+  affirmation: 'Positive Feedback',
+  is_healthy: 'true or false',
   mood: 'Inferred Mood from Thought',
   tags: ['Array', 'of', 'Relevant', 'Tags']
 };

--- a/backend/src/controllers/entry/entry.js
+++ b/backend/src/controllers/entry/entry.js
@@ -49,9 +49,7 @@ export const createEntry = async (req, res, next) => {
 
     // Get the analysis content for the entry
     try {
-      const response = await newAnalysis.getAnalysisContent(journal.config, newEntry.content);
-      // Parse the response
-      const analysis = JSON.parse(response);
+      const analysis = await newAnalysis.getAnalysisContent(journal.config, newEntry.content);
 
       // Complete the entry and analysis with the analysis content if available
       if (analysis) {
@@ -114,9 +112,7 @@ export const updateEntry = async (req, res, next) => {
     const oldAnalysis = await EntryAnalysis.findOne({ entry: entryId });
 
     try {
-      const response = await oldAnalysis.getAnalysisContent(journal.config, updatedEntry.content);
-      // Parse the response
-      const analysis = JSON.parse(response);
+      const analysis = await oldAnalysis.getAnalysisContent(journal.config, updatedEntry.content);
 
       if (analysis) {
         updatedEntry.title = analysis.title;
@@ -211,9 +207,7 @@ export const updateEntryAnalysis = async (req, res, next) => {
   const entryAnalysis = await EntryAnalysis.findOne({ entry: entryId });
 
   try {
-    const response = await entryAnalysis.getAnalysisContent(journal.config, entry.content);
-    // Parse the response
-    const analysis = JSON.parse(response);
+    const analysis = await entryAnalysis.getAnalysisContent(journal.config, entry.content);
 
     // Complete the entry and analysis with the analysis content if available
     if (analysis) {

--- a/backend/src/models/entry/entryAnalysis.js
+++ b/backend/src/models/entry/entryAnalysis.js
@@ -50,13 +50,19 @@ entryAnalysisSchema.methods.getAnalysisContent = async function (configId, conte
   cdGpt.seedAnalysisMessages();
   cdGpt.addUserMessage({ analysis: content });
 
-  const response = await cdGpt.getAnalysisCompletion();
+  const analysisCompletion = await cdGpt.getAnalysisCompletion();
 
-  if (response.error) {
-    throw new Error(response.error.message);
+  if (analysisCompletion.error) {
+    throw new Error(analysisCompletion.error.message);
   }
 
-  return response.choices[0].message.content;
+  const response = JSON.parse(analysisCompletion.choices[0].message.content);
+
+  const { reframed_thought: reframing, distortion_analysis: analysis, impact_assessment: impact, affirmation, is_healthy: isHealthy } = response;
+
+  if (!isHealthy) { response.analysis_content = analysis + ' ' + impact + ' Think, "' + reframing + '"' || affirmation; } else response.analysis_content = affirmation;
+
+  return response;
 };
 
 export default model('EntryAnalysis', entryAnalysisSchema);


### PR DESCRIPTION
This PR enforces json enabled gpts to return all required analysis topics. There are three topics that form an analysis of a thought containing a cognitive distortion,
1. A reframing or an example of what a healthy thought looks like in context
2. A label and description of the cognitive distortion e.g. over-generalization, all-or-nothing thinking, etc.
3. An assessment of the impact having that cognitive distortion may cause

If the thought does not contain a cognitive distortion, the gpt returns a single topic
1. A positive affirmation or encouragement

This has been enabled through removing `analyis_content` from the instruction format and replaces it with `reframed_thought`, `distortion_analysis`, and `impact_assessment` used to form the `analysis_content` stored in the db on return. By concatenating these topics together, it was made possible to keep `analysis_content`, which is used throughout several places on the frontend and backend. So these changes only needed to occur in one spot, in the `entryAnalysis` model methods.

As a result of forming the `analysis_content` after retrieving the gpt content, json is being parsed within the `entryAnalysis` model methods previously parsed in the entry controllers. This required going through each of those controllers and removing the JSON parsing method.

This PR closes #93. See the discussion there for more information on how the prompt has been changed. Note that the prompt was slowly iterated over to form the current working one so not all prompt attempts have been shown there.