### PR TITLE
Remove required from entryAnalysis analysis_content and entry title.

### DIFF
--- a/backend/src/models/entry/entry.js
+++ b/backend/src/models/entry/entry.js
@@ -3,7 +3,7 @@ import Joi from 'joi';
 
 const entrySchema = new Schema({
   journal: { type: Schema.Types.ObjectId, ref: 'Journal', required: true },
-  title: { type: String, required: true },
+  title: { type: String, default: 'Untitled' },
   content: { type: String, required: true },
   mood: { type: String },
   tags: [{ type: String }],

--- a/backend/src/models/entry/entryAnalysis.js
+++ b/backend/src/models/entry/entryAnalysis.js
@@ -8,7 +8,7 @@ import Joi from 'joi';
 
 const entryAnalysisSchema = new Schema({
   entry: { type: Schema.Types.ObjectId, ref: 'Entry', required: true },
-  analysis_content: { type: String, required: true },
+  analysis_content: { type: String, default: 'Analysis not available' },
   created_at: { type: Date, default: Date.now },
   updated_at: { type: Date, default: Date.now }
 });
@@ -60,7 +60,13 @@ entryAnalysisSchema.methods.getAnalysisContent = async function (configId, conte
 
   const { reframed_thought: reframing, distortion_analysis: analysis, impact_assessment: impact, affirmation, is_healthy: isHealthy } = response;
 
-  if (!isHealthy) { response.analysis_content = analysis + ' ' + impact + ' Think, "' + reframing + '"' || affirmation; } else response.analysis_content = affirmation;
+  if (!isHealthy) {
+    if (!analysis || !impact || !reframing) {
+      throw new Error('Analysis content is not available.');
+    }
+
+    response.analysis_content = analysis + ' ' + impact + ' Think, "' + reframing + '"' || affirmation;
+  } else response.analysis_content = affirmation;
 
   return response;
 };


### PR DESCRIPTION
This PR fixes a bug that causes the users session to stall. This occurs in two places.

1. When the gpt does not return the response data structure as expected. While it usually always returns json, on several occasions depending on the users input, the gpt will not always return the required keys.

If "test" is used as an entry, there's nothing to analyze, so the gpt returns nothing. The issue with this is that a title was required throwing a validation error.

2. When a first entry is posted. 

The entryAnalysis validation looks for a required analysis_content field. There is none until the gpt creates one so validation throws an error.

These errors arose after updating the analysis seed. To fix these problems, required properties have been removed from title and anaysis_content and replaced with default values.