### PR TITLE
Add default title to journal.

### DIFF
--- a/backend/src/models/journal.js
+++ b/backend/src/models/journal.js
@@ -4,17 +4,15 @@ import Joi from 'joi';
 const journalSchema = new Schema({
   user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
   config: { type: Schema.Types.ObjectId, ref: 'Config' },
-  title: { type: String, required: false },
+  title: { type: String, default: 'The Cognitive Distortion Journal' },
   created_at: { type: Date, default: Date.now },
   updated_at: { type: Date, default: Date.now }
 });
 
 journalSchema.statics.joi = Joi.object({
   title: Joi.string()
-    .allow('')
     .max(100)
     .trim()
-    .empty('')
     .default('The Cognitive Distortion Journal')
 });
 


### PR DESCRIPTION
This PR fixes a bug where the initial title of a new journal does not populate. This was likely due it not being required and the JOI validation having conflicting rules. JOI validation removes `allow` and `empty` rules for empty strings and instead depends on the default value to populate the title if it does happen to be empty. Note that this fallback very likely won't happen now that the default value has been explicitly set.