### PR TITLE
139 Utils Migration

### DIFF
--- a/backend/data/seed.js
+++ b/backend/data/seed.js
@@ -17,8 +17,6 @@ import {
   User,
 } from '../src/models/index.js';
 
-import { MongoMemoryServer } from 'mongodb-memory-server';
-
 import analyses from './analysisData.js';
 import configData from './configData.js';
 import conversations from './conversationData.js';

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3759,9 +3759,9 @@
       "dev": true
     },
     "node_modules/@types/superagent": {
-      "version": "8.1.8",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.8.tgz",
-      "integrity": "sha512-nTqHJ2OTa7PFEpLahzSEEeFeqbMpmcN7OeayiOc7v+xk+/vyTKljRe+o4MPqSnPeRCMvtxuLG+5QqluUVQJOnA==",
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
       "dev": true,
       "dependencies": {
         "@types/cookiejar": "^2.1.5",
@@ -12293,9 +12293,9 @@
       "dev": true
     },
     "node_modules/tsx": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.17.0.tgz",
-      "integrity": "sha512-eN4mnDA5UMKDt4YZixo9tBioibaMBpoxBkD+rIPAjVmYERSG0/dWEY1CEFuV89CgASlKL499q8AhmkMnnjtOJg==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.0.tgz",
+      "integrity": "sha512-bV30kM7bsLZKZIOCHeMNVMJ32/LuJzLVajkQI/qf92J2Qr08ueLQvW00PUZGiuLPP760UINwupgUj8qrSCPUKg==",
       "dev": true,
       "dependencies": {
         "esbuild": "~0.23.0",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,60 +7,91 @@
 
 /* eslint-disable sort-imports */
 
-import dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
 
 import app from './app.js';
 import fs from 'fs';
+import http from 'http';
 import https from 'https';
-import { Server } from 'http';
 
-const port = process.env.PORT;
-export let server: Server<never, never>;
+// Start the server.
+export const server: http.Server | https.Server| undefined = startServer();
 
-if (process.env.NODE_ENV !== 'production') {
-  // Start the server in development or test mode
-  server = app.listen(port, () => {
-    console.log(`\nExpress listening on port ${port}`);
-  });
-} else {
-  // Start the server in production mode
-  const { PRIVATE_KEY_PATH, CERTIFICATE_PATH, CA_PATH } = process.env;
+// Shutdown the server on ctrl+C signal
+process.on('SIGINT', closeServer);
 
-  if (!PRIVATE_KEY_PATH || !CERTIFICATE_PATH || !CA_PATH) {
-    console.error(
-      'Environment variables PRIVATE_KEY_PATH, CERTIFICATE_PATH, and CA_PATH must be set'
-    );
-    throw new Error('Environment variables PRIVATE_KEY_PATH, CERTIFICATE_PATH, and CA_PATH must be set');
+// Shutdown the server on server kill signal
+process.on('SIGTERM', closeServer);
+
+/**
+ * Start the server.
+ */
+export function startServer(): http.Server | https.Server | undefined {
+  const port = process.env.NODE_ENV !== 'test' ? process.env.PORT : '0';
+  
+  if (port === undefined) {
+    throw new Error('Environment variable PORT must be set');
   }
 
-  try {
-    const privateKey = fs.readFileSync(PRIVATE_KEY_PATH, 'utf8');
-    const certificate = fs.readFileSync(CERTIFICATE_PATH, 'utf8');
-    const ca = fs.readFileSync(CA_PATH, 'utf8');
+  if (process.env.NODE_ENV !== 'production') {
+    // Start the server in development or test mode
+    const httpServer = app.listen(port, () => {
+      const address = httpServer.address();
 
-    const credentials = { key: privateKey, cert: certificate, ca };
-    const httpsServer = https.createServer(credentials, app);
-
-    httpsServer.listen(port, () => {
-      console.log(`\nHTTPS listening on port ${port}`);
+      if (address && typeof address !== 'string') {
+        console.log(`\nHTTP Express listening on port ${address.port}`);
+      } else {
+        throw new Error(`\nHTTP Express listening on non-IP socket ${address}`);
+      }
     });
-  } catch (error) {
-    console.error('HTTPS server error:', error);
+
+    return httpServer;
+  } else {
+    // Start the server in production mode
+    const { PRIVATE_KEY_PATH, CERTIFICATE_PATH, CA_PATH } = process.env;
+
+    if (!PRIVATE_KEY_PATH || !CERTIFICATE_PATH || !CA_PATH) {
+      console.error(
+        'Environment variables PRIVATE_KEY_PATH, CERTIFICATE_PATH, and CA_PATH must be set'
+      );
+      throw new Error('Environment variables PRIVATE_KEY_PATH, CERTIFICATE_PATH, and CA_PATH must be set');
+    }
+
+    try {
+      const privateKey = fs.readFileSync(PRIVATE_KEY_PATH, 'utf8');
+      const certificate = fs.readFileSync(CERTIFICATE_PATH, 'utf8');
+      const ca = fs.readFileSync(CA_PATH, 'utf8');
+
+      const credentials = { key: privateKey, cert: certificate, ca };
+      const httpsServer = https.createServer(credentials, app);
+
+      httpsServer.listen(port, () => {
+        const address = httpsServer.address();
+        
+        if (address && typeof address !== 'string') {
+          console.log(`\nHTTPS Express listening on port ${address.port}`);
+        } else {
+          throw new Error(`\nHTTPS Express listening on non-IP socket ${address}`);
+        }
+      });
+
+      return httpsServer;
+    } catch (error) {
+      console.error('HTTPS server error:', error);
+    }
   }
 }
 
 /**
- * Gracefully shutdown the server
+ * Gracefully shutdown the server.
  */
-function closeServer() {
-  server.close(() => {
+export function closeServer() {
+  server?.close(() => {
     throw new Error('Server shutdown complete');
   });
+
+  // Force shutdown after 10 seconds.
+  setTimeout(() => {
+    throw new Error('Server shutdown timed out');
+  }, 10000);
 }
-
-// Listen for SIGINT signal (Ctrl+C)
-process.on('SIGINT', closeServer);
-
-// Listen for SIGTERM signal (system shutdown)
-process.on('SIGTERM', closeServer);

--- a/backend/src/utils/ExpressError.ts
+++ b/backend/src/utils/ExpressError.ts
@@ -1,5 +1,6 @@
 export default class ExpressError extends Error {
-  constructor(message, statusCode) {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
     super();
     this.message = message;
     this.statusCode = statusCode;

--- a/backend/src/utils/aes.ts
+++ b/backend/src/utils/aes.ts
@@ -3,14 +3,12 @@
  */
 
 import crypto from 'crypto';
-import dotenv from 'dotenv';
-
-dotenv.config();
+import 'dotenv/config';
 
 const { ENCRYPTION_KEY } = process.env;
 const IV_LENGTH = 16;
 
-export function encrypt(text) {
+export function encrypt(text: string) {
   if (!ENCRYPTION_KEY) {
     throw new Error('Encryption key is not set!');
   }
@@ -24,13 +22,13 @@ export function encrypt(text) {
   return iv.toString('hex') + ':' + encrypted.toString('hex');
 }
 
-export function decrypt(text) {
+export function decrypt(text: string) {
   if (!ENCRYPTION_KEY) {
     throw new Error('Encryption key is not set!');
   }
 
-  const textParts = text.split(':');
-  const iv = Buffer.from(textParts.shift(), 'hex');
+  const textParts: string[] = text.split(':');
+  const iv = Buffer.from(textParts.shift() || '', 'hex');
   const encryptedText = Buffer.from(textParts.join(':'), 'hex');
   const decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(ENCRYPTION_KEY), iv);
   let decrypted = decipher.update(encryptedText);

--- a/backend/src/utils/aes.ts
+++ b/backend/src/utils/aes.ts
@@ -5,16 +5,15 @@
 import crypto from 'crypto';
 import 'dotenv/config';
 
-const { ENCRYPTION_KEY } = process.env;
 const IV_LENGTH = 16;
 
 export function encrypt(text: string) {
-  if (!ENCRYPTION_KEY) {
+  if (!process.env.ENCRYPTION_KEY) {
     throw new Error('Encryption key is not set!');
   }
 
   const iv = crypto.randomBytes(IV_LENGTH);
-  const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(ENCRYPTION_KEY), iv);
+  const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(process.env.ENCRYPTION_KEY), iv);
   let encrypted = cipher.update(text);
 
   encrypted = Buffer.concat([encrypted, cipher.final()]);
@@ -23,14 +22,14 @@ export function encrypt(text: string) {
 }
 
 export function decrypt(text: string) {
-  if (!ENCRYPTION_KEY) {
+  if (!process.env.ENCRYPTION_KEY) {
     throw new Error('Encryption key is not set!');
   }
 
   const textParts: string[] = text.split(':');
   const iv = Buffer.from(textParts.shift() || '', 'hex');
   const encryptedText = Buffer.from(textParts.join(':'), 'hex');
-  const decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(ENCRYPTION_KEY), iv);
+  const decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(process.env.ENCRYPTION_KEY), iv);
   let decrypted = decipher.update(encryptedText);
 
   decrypted = Buffer.concat([decrypted, decipher.final()]);

--- a/backend/src/utils/aes.ts
+++ b/backend/src/utils/aes.ts
@@ -2,8 +2,8 @@
  * AES encryption/decryption.
  */
 
-import crypto from 'crypto';
 import 'dotenv/config';
+import crypto from 'crypto';
 
 const IV_LENGTH = 16;
 

--- a/backend/src/utils/catchAsync.js
+++ b/backend/src/utils/catchAsync.js
@@ -1,5 +1,0 @@
-export default function catchAsync(fn) {
-  return (req, res, next) => {
-    fn(req, res, next).catch(next);
-  };
-}

--- a/backend/src/utils/catchAsync.ts
+++ b/backend/src/utils/catchAsync.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 
-export default function catchAsync(fn: (req: Request, res: Response, next: NextFunction) => Promise<any>) {
+export default function catchAsync(fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>) {
   return (req: Request, res: Response, next: NextFunction) => {
     fn(req, res, next).catch(next);
   };

--- a/backend/src/utils/catchAsync.ts
+++ b/backend/src/utils/catchAsync.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 
-export default function catchAsync(fn: Function) {
+export default function catchAsync(fn: (req: Request, res: Response, next: NextFunction) => Promise<any>) {
   return (req: Request, res: Response, next: NextFunction) => {
     fn(req, res, next).catch(next);
   };

--- a/backend/src/utils/catchAsync.ts
+++ b/backend/src/utils/catchAsync.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from "express";
+
+export default function catchAsync(fn: Function) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    fn(req, res, next).catch(next);
+  };
+}

--- a/backend/src/utils/catchAsync.ts
+++ b/backend/src/utils/catchAsync.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from "express";
+import { NextFunction, Request, Response } from 'express';
 
 export default function catchAsync(fn: (req: Request, res: Response, next: NextFunction) => Promise<any>) {
   return (req: Request, res: Response, next: NextFunction) => {

--- a/backend/tests/index.test.ts
+++ b/backend/tests/index.test.ts
@@ -1,5 +1,5 @@
-import { server } from '../src/index.ts';
 import { seedDatabase, teardownDatabase } from '../data/seed.js';
+import { server } from '../src/index.js';
 
 global.console.log = jest.fn();
 
@@ -10,17 +10,16 @@ beforeAll(async () => {
 afterAll(async () => {
   console.log('Teardown: Dropping test database...');
   await teardownDatabase();
-  server.close();
+  server?.close();
 });
 
 describe('Server startup', () => {
-  it('should start the server in non-production mode', (done) => {
-    process.env.NODE_ENV = 'development';
-    setTimeout(() => {
-      expect(console.log).toHaveBeenCalledWith(
-        `\nExpress listening on port ${process.env.PORT}`
-      );
-      done();
-    }, 1000);
+  it('should start the server in non-production mode', () => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    const address = server?.address();
+    if (address && typeof address !== 'string') {
+      const { port } = address;
+      expect(console.log).toHaveBeenCalledWith(`\nHTTP Express listening on port ${port}`);
+    }
   });
 });

--- a/backend/tests/index.test.ts
+++ b/backend/tests/index.test.ts
@@ -1,14 +1,19 @@
-import mongoose from 'mongoose';
 import { server } from '../src/index.ts';
+import { seedDatabase, teardownDatabase } from '../data/seed.js';
 
 global.console.log = jest.fn();
 
-describe('Server startup', () => {
-  afterAll(async () => {
-    server.close();
-    await mongoose.connection.close();
-  });
+beforeAll(async () => {
+  await seedDatabase();
+});
 
+afterAll(async () => {
+  console.log('Teardown: Dropping test database...');
+  await teardownDatabase();
+  server.close();
+});
+
+describe('Server startup', () => {
   it('should start the server in non-production mode', (done) => {
     process.env.NODE_ENV = 'development';
     setTimeout(() => {

--- a/backend/tests/jest.setup.cjs
+++ b/backend/tests/jest.setup.cjs
@@ -5,15 +5,12 @@ const mongoose = require('mongoose');
 module.exports = async () => {
   console.log('\nSetup: config mongodb for testing...');
   // https://typegoose.github.io/mongodb-memory-server/docs/guides/integration-examples/test-runners/
-  if (process.env.MEMORY === "True") { // Config to decide if an mongodb-memory-server instance should be used
-    // it's needed in global space, because we don't want to create a new instance every test-suite
-    const instance = await MongoMemoryServer.create();
-    const uri = instance.getUri();
-    global.__MONGOINSTANCE = instance;
-    process.env.MONGO_URI = uri.slice(0, uri.lastIndexOf('/'));
-  }
+  const instance = await MongoMemoryServer.create();
+  const uri = instance.getUri();
+  global.__MONGOINSTANCE = instance;
+  process.env.MONGO_URI = uri.slice(0, uri.lastIndexOf('/'));
 
-  // The following is to make sure the database is clean before a test suite starts
+  // Make sure the database is empty before running tests.
   const conn = await mongoose.connect(`${process.env.MONGO_URI}/cdj`);
   await conn.connection.db.dropDatabase();
   await mongoose.disconnect();

--- a/backend/tests/jest.teardown.cjs
+++ b/backend/tests/jest.teardown.cjs
@@ -3,8 +3,6 @@ require('dotenv').config();
 module.exports = async () => {
   console.log('Teardown: Dropping test database...');
   // https://typegoose.github.io/mongodb-memory-server/docs/guides/integration-examples/test-runners/
-  if (process.env.MEMORY === "True") { // Config to decide if an mongodb-memory-server instance should be used
-    const instance = global.__MONGOINSTANCE;
-    await instance.stop();
-  }
+  const instance = global.__MONGOINSTANCE;
+  await instance.stop();
 };

--- a/backend/tests/jest.teardown.cjs
+++ b/backend/tests/jest.teardown.cjs
@@ -1,6 +1,10 @@
+require('dotenv').config();
+
 module.exports = async () => {
   console.log('Teardown: Dropping test database...');
-
-  const seedModule = await import('../data/seed.js');
-  await seedModule.teardownDatabase();
+  // https://typegoose.github.io/mongodb-memory-server/docs/guides/integration-examples/test-runners/
+  if (process.env.MEMORY === "True") { // Config to decide if an mongodb-memory-server instance should be used
+    const instance = global.__MONGOINSTANCE;
+    await instance.stop();
+  }
 };

--- a/backend/tests/utils/ExpressError.test.ts
+++ b/backend/tests/utils/ExpressError.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+
+import ExpressError from '../../src/utils/ExpressError.js';
+
+describe('ExpressError tests', () => {
+  it('constructs a new ExpressError', () => {
+    let expressError = new ExpressError('test', 404);
+
+    expect(expressError.message).toBe('test');
+    expect(expressError.statusCode).toBe(404);
+  });
+});

--- a/backend/tests/utils/ExpressError.test.ts
+++ b/backend/tests/utils/ExpressError.test.ts
@@ -6,7 +6,7 @@ import ExpressError from '../../src/utils/ExpressError.js';
 
 describe('ExpressError tests', () => {
   it('constructs a new ExpressError', () => {
-    let expressError = new ExpressError('test', 404);
+    const expressError = new ExpressError('test', 404);
 
     expect(expressError.message).toBe('test');
     expect(expressError.statusCode).toBe(404);

--- a/backend/tests/utils/aes.test.ts
+++ b/backend/tests/utils/aes.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { encrypt, decrypt } from '../../src/utils/aes.js';
+import { decrypt, encrypt } from '../../src/utils/aes.js';
 
 describe('AES tests', () => {
   const originalKey = process.env.ENCRYPTION_KEY;
@@ -13,7 +13,7 @@ describe('AES tests', () => {
 
   afterAll(() => {
     process.env.ENCRYPTION_KEY = originalKey;
-  })
+  });
 
   it('throws error when encryption key not set', () => {
     process.env.ENCRYPTION_KEY = '';
@@ -82,7 +82,7 @@ describe('AES tests', () => {
 
     process.env.ENCRYPTION_KEY = 'a'.repeat(32);
     expect(() => {
-      decrypt(encrypted)
+      decrypt(encrypted);
     }).toThrow();
   });
 
@@ -90,7 +90,7 @@ describe('AES tests', () => {
     const invalidCiphertext = 'invalidCiphertext';
 
     expect(() => {
-      decrypt(invalidCiphertext)
+      decrypt(invalidCiphertext);
     }).toThrow();
   });
 

--- a/backend/tests/utils/aes.test.ts
+++ b/backend/tests/utils/aes.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment node
+ */
+import { encrypt, decrypt } from '../../src/utils/aes.js';
+
+describe('AES tests', () => {
+  const originalKey = process.env.ENCRYPTION_KEY;
+  const testKey = '12345678901234567890123456789012';
+
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = testKey;
+  });
+
+  afterAll(() => {
+    process.env.ENCRYPTION_KEY = originalKey;
+  })
+
+  it('throws error when encryption key not set', () => {
+    process.env.ENCRYPTION_KEY = '';
+    expect(() => {
+      encrypt('');
+    }).toThrow(new Error('Encryption key is not set!'));
+
+    expect(() => {
+      decrypt('');
+    }).toThrow(new Error('Encryption key is not set!'));
+  });
+
+  it('throws error with improper encryption key', () => {
+    process.env.ENCRYPTION_KEY = '1234567890';
+    expect(() => {
+      encrypt('');
+    }).toThrow(new Error('Invalid key length'));
+  });
+
+  it('encrypts and decrypts simple strings correctly', () => {
+    const testPlaintext = 'Hello, World!';
+    const encrypted = encrypt(testPlaintext);
+    const decrypted = decrypt(encrypted);
+
+    expect(decrypted).toBe(testPlaintext);
+  });
+
+  it('handles empty strings', () => {
+    const testPlaintext = '';
+    const encrypted = encrypt(testPlaintext);
+    const decrypted = decrypt(encrypted);
+
+    expect(encrypted).not.toBe('');
+    expect(decrypted).toBe(testPlaintext);
+  });
+
+  it('handles strings with special characters', () => {
+    const testPlaintext = 'Thís ís å tèst strîng with spécîål chåråctèrs! @#£€%&*()_+';
+    const encrypted = encrypt(testPlaintext);
+    const decrypted = decrypt(encrypted);
+
+    expect(decrypted).toBe(testPlaintext);
+  });
+
+  it('handles long strings', () => {
+    const testPlaintext = 'a'.repeat(1000);
+    const encrypted = encrypt(testPlaintext);
+    const decrypted = decrypt(encrypted);
+
+    expect(decrypted).toBe(testPlaintext);
+  });
+
+  it('produces different ciphertexts for the same plaintext', () => {
+    const testPlaintext = 'Hello, World!';
+    const encrypted1 = encrypt(testPlaintext);
+    const encrypted2 = encrypt(testPlaintext);
+
+    expect(encrypted1).not.toBe(encrypted2);
+    expect(decrypt(encrypted1)).toBe(testPlaintext);
+    expect(decrypt(encrypted2)).toBe(testPlaintext);
+  });
+
+  it('throws an error if decrypting with the wrong encryption key', () => {
+    const testPlaintext = 'Hello, World!';
+    const encrypted = encrypt(testPlaintext);
+
+    process.env.ENCRYPTION_KEY = 'a'.repeat(32);
+    expect(() => {
+      decrypt(encrypted)
+    }).toThrow();
+  });
+
+  it('throws an error when decrypting malformed ciphertext', () => {
+    const invalidCiphertext = 'invalidCiphertext';
+
+    expect(() => {
+      decrypt(invalidCiphertext)
+    }).toThrow();
+  });
+
+  it('encrypts strings with colon delimiter without error', () => {
+    const testPlaintext = ':Hello, World!';
+    const encrypted = encrypt(testPlaintext);
+    const decrypted = decrypt(encrypted);
+
+    expect(decrypted).toBe(testPlaintext);
+  });
+});

--- a/backend/tests/utils/catchAsync.test.ts
+++ b/backend/tests/utils/catchAsync.test.ts
@@ -1,0 +1,15 @@
+/**
+ * @jest-environment node
+ */
+
+import catchAsync from '../../src/utils/catchAsync.js';
+
+describe('catchAsync tests', () => {
+  it('calls function passed into catchAsync', () => {
+    let mockfn = jest.fn();
+
+    let res = catchAsync(mockfn);
+
+    expect(res).toBeInstanceOf(Function)
+  }); 
+});

--- a/backend/tests/utils/catchAsync.test.ts
+++ b/backend/tests/utils/catchAsync.test.ts
@@ -6,10 +6,10 @@ import catchAsync from '../../src/utils/catchAsync.js';
 
 describe('catchAsync tests', () => {
   it('calls function passed into catchAsync', () => {
-    let mockfn = jest.fn();
+    const mockfn = jest.fn();
 
-    let res = catchAsync(mockfn);
+    const res = catchAsync(mockfn);
 
-    expect(res).toBeInstanceOf(Function)
+    expect(res).toBeInstanceOf(Function);
   }); 
 });


### PR DESCRIPTION
Utils directory migration to Typescript plus unit tests. Also includes changes to jest setup and teardown scripts, and seed.js.

Migrating ExpressError to TS breaks imports for jest setup and teardown scripts. They seem to run before the transformer runs. This issue will affect any module that seed.js imports that would be converted to TS, i.e. the entire models directory. This PR avoids importing seed.js in the globalsetup and globalteardown scripts to manage a memory mongodb instance. Seeding the test db happens before every test suite that uses the db.